### PR TITLE
feat: add configurable retry delay types and improve connection handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/javi11/nntpcli v0.5.0
+	github.com/javi11/nntpcli v0.6.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.0
 	golang.org/x/text v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/javi11/nntp-server-mock v0.0.1 h1:05KbUlFSnzk82CG/sHWLp9s6Vg8exL3wvdAetX8Bwhc=
 github.com/javi11/nntp-server-mock v0.0.1/go.mod h1:+QBpPor0q44ttab8kWo08+/t5C26IHhUpBTC1lZqujA=
-github.com/javi11/nntpcli v0.5.0 h1:AS5p/at3i21H7ULsxRMBDSjzgUoID4U6jZJ8yMtZSt8=
-github.com/javi11/nntpcli v0.5.0/go.mod h1:dMqGOavcFyeGKQZei+6QYUfn2BF29S1t36B0dA7vnFA=
+github.com/javi11/nntpcli v0.6.0 h1:IUXL2qDXbg54Cp6SB0OGuDcOhXk8hr0+rI6ioGxBhbA=
+github.com/javi11/nntpcli v0.6.0/go.mod h1:dMqGOavcFyeGKQZei+6QYUfn2BF29S1t36B0dA7vnFA=
 github.com/jgautheron/goconst v1.7.1 h1:VpdAG7Ca7yvvJk5n8dMwQhfEZJh95kl/Hl9S1OI5Jkk=
 github.com/jgautheron/goconst v1.7.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjzq7gFzUs=


### PR DESCRIPTION
This pull request introduces configurable retry delay strategies, enhances error handling for provider rotation during retries, and updates dependencies. The changes improve the flexibility and robustness of the connection pool implementation and add test coverage for new functionality.

### Configurable Retry Delay Strategies:
* Added a new `DelayType` enum (`DelayTypeFixed`, `DelayTypeRandom`, `DelayTypeExponential`) and corresponding logic to configure retry delay strategies in the `Config` struct. The `mergeWithDefault` function now maps these delay types to the appropriate `retry-go` delay functions (`FixedDelay`, `RandomDelay`, `BackOffDelay`). (`config.go`: [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R25-R42) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R121-R131)
* Updated retry logic in the `Body`, `Post`, and `Stat` methods of the `connectionPool` to use the configured `delayTypeFn` instead of the default `FixedDelay`. (`connection_pool.go`: [[1]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL282-R290) [[2]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL392-R397) [[3]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL517-R540)

### Enhanced Error Handling for Provider Rotation:
* Enhanced the `Post` method to handle cases where a segment already exists on a provider. When this error occurs, the provider is skipped, and the operation retries with the next available provider. (`connection_pool.go`: [[1]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dR411-R421) [[2]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dR433)
* Added a new unit test to verify that the `Post` method rotates providers correctly when encountering a "segment already exists" error. (`connection_pool_test.go`: [[1]](diffhunk://#diff-d4ce4398942e47c36f819931315b0bac16c435a21f7384650c291082bee2243aR580-R615) [[2]](diffhunk://#diff-d4ce4398942e47c36f819931315b0bac16c435a21f7384650c291082bee2243aL589-R627)

### Dependency Updates:
* Upgraded the `nntpcli` library from version `v0.5.0` to `v0.6.0` in `go.mod` to ensure compatibility with the new functionality. (`go.mod`: [go.modL9-R9](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L9-R9))
* Added `github.com/avast/retry-go` to `config.go` imports to support retry delay strategies. (`config.go`: [config.goR9](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R9))

### Minor Improvements:
* Improved logging messages in the `Body`, `Post`, and `Stat` methods to better reflect the operation being retried or exhausted. (`connection_pool.go`: [[1]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL339-R341) [[2]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL574-R591)