### PR TITLE
fix(metrics): Enhance active connection tracking and metrics reporting

### DIFF
--- a/connection_pool.go
+++ b/connection_pool.go
@@ -270,11 +270,18 @@ func (p *connectionPool) GetConnection(
 	// Record successful acquire timing
 	p.metrics.RecordAcquireWaitTime(time.Since(start))
 
-	return pooledConnection{
+	pooledConn := pooledConnection{
 		resource: conn,
 		log:      p.log,
 		metrics:  p.metrics,
-	}, nil
+	}
+
+	// Register the connection as active for metrics tracking
+	if conn.Value().nntp != nil {
+		p.metrics.RegisterActiveConnection(pooledConn.connectionID(), conn.Value().nntp)
+	}
+
+	return pooledConn, nil
 }
 
 func (p *connectionPool) GetProvidersInfo() []ProviderInfo {

--- a/example_metrics_usage.go
+++ b/example_metrics_usage.go
@@ -33,12 +33,22 @@ func ExampleMetricsUsage() {
 
 	// Get real-time metrics
 	metrics := pool.GetMetrics()
+	activeMetrics := metrics.GetActiveConnectionMetrics()
 
 	fmt.Printf("Active connections: %d\n", metrics.GetActiveConnections())
+	fmt.Printf("Tracked active connections: %d\n", activeMetrics.Count)
 	fmt.Printf("Total acquires: %d\n", metrics.GetTotalAcquires())
 	fmt.Printf("Total bytes downloaded: %d\n", metrics.GetTotalBytesDownloaded())
 	fmt.Printf("Total bytes uploaded: %d\n", metrics.GetTotalBytesUploaded())
 	fmt.Printf("Pool uptime: %v\n", metrics.GetUptime())
+
+	// Show active connection specific metrics
+	fmt.Printf("\n=== Active Connection Metrics ===\n")
+	fmt.Printf("Active connections count: %d\n", activeMetrics.Count)
+	fmt.Printf("Active bytes downloaded: %d\n", activeMetrics.TotalBytesDownloaded)
+	fmt.Printf("Active bytes uploaded: %d\n", activeMetrics.TotalBytesUploaded)
+	fmt.Printf("Active commands: %d\n", activeMetrics.TotalCommands)
+	fmt.Printf("Active success rate: %.2f%%\n", activeMetrics.SuccessRate)
 
 	// Get comprehensive snapshot
 	snapshot := pool.GetMetricsSnapshot()
@@ -107,14 +117,16 @@ func MonitoringExample() {
 				return
 			case <-ticker.C:
 				metrics := pool.GetMetrics()
+				activeMetrics := metrics.GetActiveConnectionMetrics()
 
 				// Monitor key performance indicators
 				activeConns := metrics.GetActiveConnections()
+				trackedActiveConns := activeMetrics.Count
 				errorRate := float64(metrics.GetTotalErrors()) / float64(metrics.GetTotalAcquires()) * 100
 				avgWaitTime := metrics.GetAverageAcquireWaitTime()
 
-				fmt.Printf("[%v] Active: %d, Error Rate: %.2f%%, Avg Wait: %v\n",
-					time.Now().Format("15:04:05"), activeConns, errorRate, avgWaitTime)
+				fmt.Printf("[%v] Active: %d (tracked: %d), Error Rate: %.2f%%, Avg Wait: %v, Active Cmds: %d\n",
+					time.Now().Format("15:04:05"), activeConns, trackedActiveConns, errorRate, avgWaitTime, activeMetrics.TotalCommands)
 
 				// Alert on high error rates
 				if errorRate > 5.0 {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,11 +1,14 @@
 package nntppool
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/javi11/nntpcli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestPoolMetrics_Basic(t *testing.T) {
@@ -107,7 +110,7 @@ func TestPoolMetrics_AcquireWaitTime(t *testing.T) {
 
 	metrics.RecordAcquire()
 	metrics.RecordAcquireWaitTime(duration1)
-	
+
 	metrics.RecordAcquire()
 	metrics.RecordAcquireWaitTime(duration2)
 
@@ -118,10 +121,10 @@ func TestPoolMetrics_AcquireWaitTime(t *testing.T) {
 
 func TestPoolMetrics_Uptime(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Sleep for a short time to ensure uptime is measurable
 	time.Sleep(10 * time.Millisecond)
-	
+
 	uptime := metrics.GetUptime()
 	assert.True(t, uptime > 10*time.Millisecond)
 	assert.True(t, uptime < 1*time.Second) // Should be reasonable
@@ -129,20 +132,20 @@ func TestPoolMetrics_Uptime(t *testing.T) {
 
 func TestPoolMetrics_ConcurrentAccess(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Test concurrent access to metrics (should not panic)
 	done := make(chan bool, 10)
-	
+
 	for i := 0; i < 10; i++ {
 		go func() {
 			defer func() { done <- true }()
-			
+
 			for j := 0; j < 100; j++ {
 				metrics.RecordConnectionCreated()
 				metrics.RecordAcquire()
 				metrics.RecordBytesDownloaded(int64(j))
 				metrics.RecordCommand()
-				
+
 				// Read metrics
 				_ = metrics.GetTotalConnectionsCreated()
 				_ = metrics.GetTotalAcquires()
@@ -151,12 +154,12 @@ func TestPoolMetrics_ConcurrentAccess(t *testing.T) {
 			}
 		}()
 	}
-	
+
 	// Wait for all goroutines to complete
 	for i := 0; i < 10; i++ {
 		<-done
 	}
-	
+
 	// Verify final state
 	assert.Equal(t, int64(1000), metrics.GetTotalConnectionsCreated())
 	assert.Equal(t, int64(1000), metrics.GetTotalAcquires())
@@ -166,10 +169,10 @@ func TestPoolMetrics_ConcurrentAccess(t *testing.T) {
 
 func TestPoolMetrics_EmptySnapshot(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Test snapshot with no pools
 	snapshot := metrics.GetSnapshot(nil)
-	
+
 	assert.NotZero(t, snapshot.Timestamp)
 	assert.True(t, snapshot.Uptime >= 0)
 	assert.Equal(t, int64(0), snapshot.TotalConnectionsCreated)
@@ -181,7 +184,7 @@ func TestPoolMetrics_EmptySnapshot(t *testing.T) {
 
 func TestPoolMetrics_SnapshotCalculations(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Add some metrics data
 	metrics.RecordBytesDownloaded(1000)
 	metrics.RecordBytesUploaded(500)
@@ -190,17 +193,17 @@ func TestPoolMetrics_SnapshotCalculations(t *testing.T) {
 	metrics.RecordCommandError()
 	metrics.RecordAcquire()
 	metrics.RecordError()
-	
+
 	// Wait a bit to ensure uptime is measurable
 	time.Sleep(10 * time.Millisecond)
-	
+
 	snapshot := metrics.GetSnapshot(nil)
-	
+
 	// Verify calculated fields
-	assert.True(t, snapshot.DownloadSpeed > 0) // Should be bytes/second
-	assert.True(t, snapshot.UploadSpeed > 0)   // Should be bytes/second
+	assert.True(t, snapshot.DownloadSpeed > 0)                // Should be bytes/second
+	assert.True(t, snapshot.UploadSpeed > 0)                  // Should be bytes/second
 	assert.Equal(t, float64(50), snapshot.CommandSuccessRate) // 1 success out of 2 commands = 50%
-	assert.Equal(t, float64(100), snapshot.ErrorRate) // 1 error out of 1 acquire = 100%
+	assert.Equal(t, float64(100), snapshot.ErrorRate)         // 1 error out of 1 acquire = 100%
 	assert.Equal(t, int64(1000), snapshot.TotalBytesDownloaded)
 	assert.Equal(t, int64(500), snapshot.TotalBytesUploaded)
 }
@@ -209,7 +212,7 @@ func TestPoolMetrics_SnapshotCalculations(t *testing.T) {
 func BenchmarkPoolMetrics_RecordConnectionCreated(b *testing.B) {
 	metrics := NewPoolMetrics()
 	b.ResetTimer()
-	
+
 	for i := 0; i < b.N; i++ {
 		metrics.RecordConnectionCreated()
 	}
@@ -218,7 +221,7 @@ func BenchmarkPoolMetrics_RecordConnectionCreated(b *testing.B) {
 func BenchmarkPoolMetrics_RecordBytesDownloaded(b *testing.B) {
 	metrics := NewPoolMetrics()
 	b.ResetTimer()
-	
+
 	for i := 0; i < b.N; i++ {
 		metrics.RecordBytesDownloaded(1024)
 	}
@@ -228,7 +231,7 @@ func BenchmarkPoolMetrics_GetTotalBytesDownloaded(b *testing.B) {
 	metrics := NewPoolMetrics()
 	metrics.RecordBytesDownloaded(1024)
 	b.ResetTimer()
-	
+
 	for i := 0; i < b.N; i++ {
 		_ = metrics.GetTotalBytesDownloaded()
 	}
@@ -237,7 +240,7 @@ func BenchmarkPoolMetrics_GetTotalBytesDownloaded(b *testing.B) {
 func BenchmarkPoolMetrics_ConcurrentOperations(b *testing.B) {
 	metrics := NewPoolMetrics()
 	b.ResetTimer()
-	
+
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			metrics.RecordConnectionCreated()
@@ -246,4 +249,188 @@ func BenchmarkPoolMetrics_ConcurrentOperations(b *testing.B) {
 			_ = metrics.GetTotalBytesDownloaded()
 		}
 	})
+}
+
+// Tests for Active Connection Tracking functionality
+
+func TestPoolMetrics_ActiveConnectionRegistry(t *testing.T) {
+	metrics := NewPoolMetrics()
+
+	// Test initial state
+	assert.Equal(t, 0, metrics.GetActiveConnectionsCount())
+	activeMetrics := metrics.GetActiveConnectionMetrics()
+	assert.Equal(t, 0, activeMetrics.Count)
+	assert.Equal(t, int64(0), activeMetrics.TotalBytesDownloaded)
+	assert.Equal(t, int64(0), activeMetrics.TotalBytesUploaded)
+	assert.Equal(t, int64(0), activeMetrics.TotalCommands)
+	assert.Equal(t, float64(0), activeMetrics.SuccessRate)
+}
+
+func TestPoolMetrics_ActiveConnectionRegistration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics := NewPoolMetrics()
+
+	// Create mock connections
+	mockConn1 := nntpcli.NewMockConnection(ctrl)
+	mockConn2 := nntpcli.NewMockConnection(ctrl)
+
+	// Create mock metrics for the connections
+	mockMetrics1 := nntpcli.NewMetrics()
+	mockMetrics2 := nntpcli.NewMetrics()
+
+	// Setup expectations for mock connections to return our metrics
+	mockConn1.EXPECT().GetMetrics().Return(mockMetrics1).AnyTimes()
+	mockConn2.EXPECT().GetMetrics().Return(mockMetrics2).AnyTimes()
+
+	// Simulate some activity on the connections
+	mockMetrics1.RecordDownload(1000)
+	mockMetrics1.RecordUpload(500)
+	for i := 0; i < 10; i++ {
+		mockMetrics1.RecordCommand(i < 9) // 9 successes, 1 failure
+	}
+
+	mockMetrics2.RecordDownload(2000)
+	mockMetrics2.RecordUpload(800)
+	for i := 0; i < 15; i++ {
+		mockMetrics2.RecordCommand(i < 13) // 13 successes, 2 failures
+	}
+
+	// Register active connections
+	metrics.RegisterActiveConnection("conn1", mockConn1)
+	assert.Equal(t, 1, metrics.GetActiveConnectionsCount())
+
+	metrics.RegisterActiveConnection("conn2", mockConn2)
+	assert.Equal(t, 2, metrics.GetActiveConnectionsCount())
+
+	// Get active metrics
+	activeMetrics := metrics.GetActiveConnectionMetrics()
+	assert.Equal(t, 2, activeMetrics.Count)
+	assert.Equal(t, int64(3000), activeMetrics.TotalBytesDownloaded) // 1000 + 2000
+	assert.Equal(t, int64(1300), activeMetrics.TotalBytesUploaded)   // 500 + 800
+	assert.Equal(t, int64(25), activeMetrics.TotalCommands)          // 10 + 15
+	assert.Equal(t, int64(3), activeMetrics.TotalCommandErrors)      // 1 + 2
+
+	// Success rate should be (25-3)/25 * 100 = 88%
+	assert.InDelta(t, 88.0, activeMetrics.SuccessRate, 0.1)
+
+	// Connection age will be very small since we just created the metrics
+	assert.True(t, activeMetrics.AverageConnectionAge > 0)
+
+	// Unregister connections
+	metrics.UnregisterActiveConnection("conn1")
+	assert.Equal(t, 1, metrics.GetActiveConnectionsCount())
+
+	metrics.UnregisterActiveConnection("conn2")
+	assert.Equal(t, 0, metrics.GetActiveConnectionsCount())
+
+	// Check final state
+	finalMetrics := metrics.GetActiveConnectionMetrics()
+	assert.Equal(t, 0, finalMetrics.Count)
+	assert.Equal(t, int64(0), finalMetrics.TotalBytesDownloaded)
+	assert.Equal(t, int64(0), finalMetrics.TotalBytesUploaded)
+}
+
+func TestPoolMetrics_ActiveConnectionConcurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics := NewPoolMetrics()
+
+	// Test concurrent registration and unregistration
+	const numGoroutines = 10
+	const connectionsPerGoroutine = 5
+
+	done := make(chan bool, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(routineID int) {
+			defer func() { done <- true }()
+
+			for j := 0; j < connectionsPerGoroutine; j++ {
+				mockConn := nntpcli.NewMockConnection(ctrl)
+				mockMetrics := nntpcli.NewMetrics()
+
+				mockConn.EXPECT().GetMetrics().Return(mockMetrics).AnyTimes()
+
+				connID := fmt.Sprintf("routine%d-conn%d", routineID, j)
+				metrics.RegisterActiveConnection(connID, mockConn)
+			}
+
+			// Unregister connections
+			for j := 0; j < connectionsPerGoroutine; j++ {
+				connID := fmt.Sprintf("routine%d-conn%d", routineID, j)
+				metrics.UnregisterActiveConnection(connID)
+			}
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < numGoroutines; i++ {
+		<-done
+	}
+
+	// Verify final state - all connections should be unregistered
+	assert.Equal(t, 0, metrics.GetActiveConnectionsCount())
+	finalMetrics := metrics.GetActiveConnectionMetrics()
+	assert.Equal(t, 0, finalMetrics.Count)
+}
+
+func TestPoolMetrics_ActiveConnectionWithNilMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics := NewPoolMetrics()
+
+	// Create mock connection that returns nil metrics
+	mockConn := nntpcli.NewMockConnection(ctrl)
+	mockConn.EXPECT().GetMetrics().Return(nil).AnyTimes()
+
+	// Register connection
+	metrics.RegisterActiveConnection("conn1", mockConn)
+	assert.Equal(t, 1, metrics.GetActiveConnectionsCount())
+
+	// Get active metrics - should handle nil metrics gracefully
+	activeMetrics := metrics.GetActiveConnectionMetrics()
+	assert.Equal(t, 0, activeMetrics.Count) // Should not count connections with nil metrics
+	assert.Equal(t, int64(0), activeMetrics.TotalBytesDownloaded)
+	assert.Equal(t, int64(0), activeMetrics.TotalBytesUploaded)
+}
+
+// Benchmark tests for active connection functionality
+func BenchmarkPoolMetrics_RegisterActiveConnection(b *testing.B) {
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+
+	metrics := NewPoolMetrics()
+	mockConn := nntpcli.NewMockConnection(ctrl)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		connID := fmt.Sprintf("conn%d", i)
+		metrics.RegisterActiveConnection(connID, mockConn)
+	}
+}
+
+func BenchmarkPoolMetrics_GetActiveConnectionMetrics(b *testing.B) {
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+
+	metrics := NewPoolMetrics()
+
+	// Register some connections
+	for i := 0; i < 100; i++ {
+		mockConn := nntpcli.NewMockConnection(ctrl)
+		mockMetrics := nntpcli.NewMetrics()
+
+		mockConn.EXPECT().GetMetrics().Return(mockMetrics).AnyTimes()
+
+		metrics.RegisterActiveConnection(fmt.Sprintf("conn%d", i), mockConn)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = metrics.GetActiveConnectionMetrics()
+	}
 }


### PR DESCRIPTION
This pull request introduces active connection tracking to the `nntppool` package, enhancing the connection pool's ability to monitor and manage real-time metrics for active connections. The changes include adding a thread-safe registry for active connections, providing detailed metrics for active connections, and updating tests and examples to reflect the new functionality.

### Enhancements to Metrics Functionality:
* Added a thread-safe `sync.Map` in `PoolMetrics` to track active connections (`metrics.go`).
* Introduced methods to register/unregister active connections (`RegisterActiveConnection`, `UnregisterActiveConnection`) and retrieve active connection metrics (`GetActiveConnectionMetrics`) (`metrics.go`).
* Extended the `aggregateConnectionMetrics` function to include metrics from both idle and active connections (`metrics.go`).

### Updates to Connection Lifecycle:
* Added a `connectionID` method to `pooledConnection` for uniquely identifying connections (`pooled_connection.go`).
* Modified `Close` and `Free` methods in `pooledConnection` to unregister connections from active tracking before releasing or destroying them (`pooled_connection.go`) [[1]](diffhunk://#diff-9ddd1d84b12cbbf9a5bba3a01e808b05eb7d77b64ff78c6f11caeeadc01366caL60-R74) [[2]](diffhunk://#diff-9ddd1d84b12cbbf9a5bba3a01e808b05eb7d77b64ff78c6f11caeeadc01366caL87-R102).

### Updates to Examples:
* Updated examples to demonstrate retrieving and displaying active connection metrics (`example_metrics_usage.go`) [[1]](diffhunk://#diff-8aae4de76ddbdb423f756f3aeba1b7ba2e488e81457ea73ecccfbaa63a5a16daR36-R52) [[2]](diffhunk://#diff-8aae4de76ddbdb423f756f3aeba1b7ba2e488e81457ea73ecccfbaa63a5a16daR120-R129).

### Test Coverage for Active Connection Tracking:
* Added unit tests for active connection registration, unregistration, and concurrency handling (`metrics_test.go`).
* Added benchmark tests for registering and retrieving active connection metrics (`metrics_test.go`).

### Miscellaneous:
* Updated imports to include the `nntpcli` dependency for connection metrics (`metrics.go`, `pooled_connection.go`, `metrics_test.go`) [[1]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R4-R8) [[2]](diffhunk://#diff-9ddd1d84b12cbbf9a5bba3a01e808b05eb7d77b64ff78c6f11caeeadc01366caR8-R10) [[3]](diffhunk://#diff-6ab5b52160d2339cd82dfa92b1b194342411073ae22f5906a0d1675334cf9be9R4-R11).