### PR TITLE
refactor(metrics): Transition traffic metrics to be aggregated from connections

### DIFF
--- a/connection_pool.go
+++ b/connection_pool.go
@@ -457,14 +457,10 @@ func (p *connectionPool) Body(
 		n, err := nntpConn.BodyDecoded(msgID, w, written)
 		if err != nil && ctx.Err() == nil {
 			written += n
-			p.metrics.RecordCommandError()
 			return fmt.Errorf("error downloading body: %w", err)
 		}
 
 		bytesWritten = n
-		p.metrics.RecordCommand()
-		p.metrics.RecordBytesDownloaded(n)
-		p.metrics.RecordArticleRetrieved()
 
 		_ = conn.Free()
 
@@ -608,11 +604,8 @@ func (p *connectionPool) BodyReader(
 
 		reader, err = nntpConn.BodyReader(msgID)
 		if err != nil && ctx.Err() == nil {
-			p.metrics.RecordCommandError()
 			return fmt.Errorf("error getting body reader: %w", err)
 		}
-
-		p.metrics.RecordCommand()
 
 		// Don't free the connection here since the reader needs it
 		// The connection will be managed by a wrapper reader
@@ -731,12 +724,8 @@ func (p *connectionPool) Post(ctx context.Context, r io.Reader) error {
 
 		err = nntpConn.Post(r)
 		if err != nil {
-			p.metrics.RecordCommandError()
 			return fmt.Errorf("error posting article: %w", err)
 		}
-
-		p.metrics.RecordCommand()
-		p.metrics.RecordArticlePosted()
 
 		_ = conn.Free()
 
@@ -876,11 +865,8 @@ func (p *connectionPool) Stat(
 
 		res, err = nntpConn.Stat(msgID)
 		if err != nil && ctx.Err() == nil {
-			p.metrics.RecordCommandError()
 			return fmt.Errorf("error checking article: %w", err)
 		}
-
-		p.metrics.RecordCommand()
 
 		_ = conn.Free()
 

--- a/example_metrics_usage.go
+++ b/example_metrics_usage.go
@@ -38,9 +38,12 @@ func ExampleMetricsUsage() {
 	fmt.Printf("Active connections: %d\n", metrics.GetActiveConnections())
 	fmt.Printf("Tracked active connections: %d\n", activeMetrics.Count)
 	fmt.Printf("Total acquires: %d\n", metrics.GetTotalAcquires())
-	fmt.Printf("Total bytes downloaded: %d\n", metrics.GetTotalBytesDownloaded())
-	fmt.Printf("Total bytes uploaded: %d\n", metrics.GetTotalBytesUploaded())
 	fmt.Printf("Pool uptime: %v\n", metrics.GetUptime())
+	
+	// Get traffic data from snapshot instead
+	snapshot := pool.GetMetricsSnapshot()
+	fmt.Printf("Total bytes downloaded: %d\n", snapshot.TotalBytesDownloaded)
+	fmt.Printf("Total bytes uploaded: %d\n", snapshot.TotalBytesUploaded)
 
 	// Show active connection specific metrics
 	fmt.Printf("\n=== Active Connection Metrics ===\n")
@@ -50,8 +53,7 @@ func ExampleMetricsUsage() {
 	fmt.Printf("Active commands: %d\n", activeMetrics.TotalCommands)
 	fmt.Printf("Active success rate: %.2f%%\n", activeMetrics.SuccessRate)
 
-	// Get comprehensive snapshot
-	snapshot := pool.GetMetricsSnapshot()
+	// Use the same snapshot for comprehensive view
 
 	fmt.Printf("\n=== Pool Metrics Snapshot ===\n")
 	fmt.Printf("Timestamp: %v\n", snapshot.Timestamp)

--- a/example_metrics_usage.go
+++ b/example_metrics_usage.go
@@ -31,8 +31,12 @@ func ExampleMetricsUsage() {
 	}
 	defer pool.Quit()
 
-	// Get real-time metrics
+	// Configure speed calculation (optional)
 	metrics := pool.GetMetrics()
+	metrics.SetSpeedWindowDuration(30 * time.Second) // Use 30-second window instead of default 60
+	metrics.SetSpeedCacheDuration(2 * time.Second)   // Cache speed calculations for 2 seconds
+	
+	// Get real-time metrics
 	activeMetrics := metrics.GetActiveConnectionMetrics()
 
 	fmt.Printf("Active connections: %d\n", metrics.GetActiveConnections())
@@ -44,6 +48,16 @@ func ExampleMetricsUsage() {
 	snapshot := pool.GetMetricsSnapshot()
 	fmt.Printf("Total bytes downloaded: %d\n", snapshot.TotalBytesDownloaded)
 	fmt.Printf("Total bytes uploaded: %d\n", snapshot.TotalBytesUploaded)
+	
+	// Show new speed metrics
+	fmt.Printf("\n=== Speed Metrics ===\n")
+	fmt.Printf("Current download speed: %.2f bytes/sec\n", snapshot.DownloadSpeed)
+	fmt.Printf("Current upload speed: %.2f bytes/sec\n", snapshot.UploadSpeed)
+	fmt.Printf("Historical download speed: %.2f bytes/sec\n", snapshot.HistoricalDownloadSpeed)
+	fmt.Printf("Historical upload speed: %.2f bytes/sec\n", snapshot.HistoricalUploadSpeed)
+	fmt.Printf("Speed calculation window: %.0f seconds\n", snapshot.SpeedCalculationWindow)
+	fmt.Printf("Speed cache duration: %.0f seconds\n", snapshot.SpeedCacheDuration)
+	fmt.Printf("Speed cache age: %.2f seconds\n", snapshot.SpeedCacheAge)
 
 	// Show active connection specific metrics
 	fmt.Printf("\n=== Active Connection Metrics ===\n")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/javi11/nntpcli v1.1.0
+	github.com/javi11/nntpcli v1.1.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.2
 	golang.org/x/text v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/jackmordaunt/icns v1.0.0 h1:RYSxplerf/l/DUd09AHtITwckkv/mqjVv4DjYdPmA
 github.com/jackmordaunt/icns v1.0.0/go.mod h1:7TTQVEuGzVVfOPPlLNHJIkzA6CoV7aH1Dv9dW351oOo=
 github.com/javi11/nntp-server-mock v0.0.1 h1:05KbUlFSnzk82CG/sHWLp9s6Vg8exL3wvdAetX8Bwhc=
 github.com/javi11/nntp-server-mock v0.0.1/go.mod h1:+QBpPor0q44ttab8kWo08+/t5C26IHhUpBTC1lZqujA=
-github.com/javi11/nntpcli v1.1.0 h1:K3J1YLgZdphbKqrwqjTms0tJOWuxmFOpnK+UsVXCsH4=
-github.com/javi11/nntpcli v1.1.0/go.mod h1:ZDb9BCQVrG1UT0XN6ikfOlYYzqrYNxXISIuLg30ZpK0=
+github.com/javi11/nntpcli v1.1.1 h1:uX7uIm40o/fpa1XbdfWTJgyExm3Wyx1SX9eFDIhVpu0=
+github.com/javi11/nntpcli v1.1.1/go.mod h1:ZDb9BCQVrG1UT0XN6ikfOlYYzqrYNxXISIuLg30ZpK0=
 github.com/jaypipes/ghw v0.13.0 h1:log8MXuB8hzTNnSktqpXMHc0c/2k/WgjOMSUtnI1RV4=
 github.com/jaypipes/ghw v0.13.0/go.mod h1:In8SsaDqlb1oTyrbmTC14uy+fbBMvp+xdqX51MidlD8=
 github.com/jaypipes/pcidb v1.0.1 h1:WB2zh27T3nwg8AE8ei81sNRb9yWBii3JGNJtT7K9Oic=

--- a/metrics.go
+++ b/metrics.go
@@ -19,16 +19,8 @@ type PoolMetrics struct {
 	totalErrors               int64 // Total operation errors
 	totalRetries              int64 // Total retry attempts
 
-	// Traffic metrics (atomic counters)
-	totalBytesDownloaded int64 // Total bytes downloaded across all connections
-	totalBytesUploaded   int64 // Total bytes uploaded across all connections
-	totalArticlesRetrieved int64 // Total articles successfully retrieved
-	totalArticlesPosted    int64 // Total articles successfully posted
-
 	// Performance metrics (atomic counters)
 	totalAcquireWaitTime int64 // Total time spent waiting for connections (nanoseconds)
-	totalCommandCount    int64 // Total NNTP commands executed
-	totalCommandErrors   int64 // Total NNTP command errors
 
 	// Timing
 	startTime int64 // Pool start time (Unix nanoseconds)
@@ -70,34 +62,9 @@ func (m *PoolMetrics) RecordRetry() {
 	atomic.AddInt64(&m.totalRetries, 1)
 }
 
-// Traffic metrics
-func (m *PoolMetrics) RecordBytesDownloaded(bytes int64) {
-	atomic.AddInt64(&m.totalBytesDownloaded, bytes)
-}
-
-func (m *PoolMetrics) RecordBytesUploaded(bytes int64) {
-	atomic.AddInt64(&m.totalBytesUploaded, bytes)
-}
-
-func (m *PoolMetrics) RecordArticleRetrieved() {
-	atomic.AddInt64(&m.totalArticlesRetrieved, 1)
-}
-
-func (m *PoolMetrics) RecordArticlePosted() {
-	atomic.AddInt64(&m.totalArticlesPosted, 1)
-}
-
 // Performance metrics
 func (m *PoolMetrics) RecordAcquireWaitTime(duration time.Duration) {
 	atomic.AddInt64(&m.totalAcquireWaitTime, int64(duration))
-}
-
-func (m *PoolMetrics) RecordCommand() {
-	atomic.AddInt64(&m.totalCommandCount, 1)
-}
-
-func (m *PoolMetrics) RecordCommandError() {
-	atomic.AddInt64(&m.totalCommandErrors, 1)
 }
 
 // Fast getters (single atomic load each)
@@ -129,29 +96,6 @@ func (m *PoolMetrics) GetTotalRetries() int64 {
 	return atomic.LoadInt64(&m.totalRetries)
 }
 
-func (m *PoolMetrics) GetTotalBytesDownloaded() int64 {
-	return atomic.LoadInt64(&m.totalBytesDownloaded)
-}
-
-func (m *PoolMetrics) GetTotalBytesUploaded() int64 {
-	return atomic.LoadInt64(&m.totalBytesUploaded)
-}
-
-func (m *PoolMetrics) GetTotalArticlesRetrieved() int64 {
-	return atomic.LoadInt64(&m.totalArticlesRetrieved)
-}
-
-func (m *PoolMetrics) GetTotalArticlesPosted() int64 {
-	return atomic.LoadInt64(&m.totalArticlesPosted)
-}
-
-func (m *PoolMetrics) GetTotalCommandCount() int64 {
-	return atomic.LoadInt64(&m.totalCommandCount)
-}
-
-func (m *PoolMetrics) GetTotalCommandErrors() int64 {
-	return atomic.LoadInt64(&m.totalCommandErrors)
-}
 
 func (m *PoolMetrics) GetAverageAcquireWaitTime() time.Duration {
 	totalWait := atomic.LoadInt64(&m.totalAcquireWaitTime)
@@ -260,12 +204,12 @@ type PoolMetricsSnapshot struct {
 	ActiveConnections         int64 `json:"active_connections"`
 	TotalAcquires             int64 `json:"total_acquires"`
 	TotalReleases             int64 `json:"total_releases"`
-	
+
 	// Pool utilization
 	AcquiredConnections int32 `json:"acquired_connections"`
 	IdleConnections     int32 `json:"idle_connections"`
 	TotalConnections    int32 `json:"total_connections"`
-	
+
 	// Traffic metrics
 	TotalBytesDownloaded   int64   `json:"total_bytes_downloaded"`
 	TotalBytesUploaded     int64   `json:"total_bytes_uploaded"`
@@ -273,29 +217,29 @@ type PoolMetricsSnapshot struct {
 	TotalArticlesPosted    int64   `json:"total_articles_posted"`
 	DownloadSpeed          float64 `json:"download_speed_bytes_per_sec"`
 	UploadSpeed            float64 `json:"upload_speed_bytes_per_sec"`
-	
+
 	// Performance metrics
-	TotalCommandCount     int64         `json:"total_command_count"`
-	TotalCommandErrors    int64         `json:"total_command_errors"`
-	CommandSuccessRate    float64       `json:"command_success_rate_percent"`
+	TotalCommandCount      int64         `json:"total_command_count"`
+	TotalCommandErrors     int64         `json:"total_command_errors"`
+	CommandSuccessRate     float64       `json:"command_success_rate_percent"`
 	AverageAcquireWaitTime time.Duration `json:"average_acquire_wait_time"`
-	
+
 	// Error metrics
-	TotalErrors        int64   `json:"total_errors"`
-	TotalRetries       int64   `json:"total_retries"`
-	ErrorRate          float64 `json:"error_rate_percent"`
-	
+	TotalErrors  int64   `json:"total_errors"`
+	TotalRetries int64   `json:"total_retries"`
+	ErrorRate    float64 `json:"error_rate_percent"`
+
 	// Provider-specific metrics
 	ProviderMetrics []ProviderMetricsSnapshot `json:"provider_metrics"`
 }
 
 // ProviderMetricsSnapshot contains metrics for a specific provider
 type ProviderMetricsSnapshot struct {
-	ProviderID   string `json:"provider_id"`
-	Host         string `json:"host"`
-	Username     string `json:"username"`
-	State        string `json:"state"`
-	
+	ProviderID string `json:"provider_id"`
+	Host       string `json:"host"`
+	Username   string `json:"username"`
+	State      string `json:"state"`
+
 	// Pool statistics from puddle
 	MaxConnections          int32         `json:"max_connections"`
 	TotalConnections        int32         `json:"total_connections"`
@@ -307,14 +251,23 @@ type ProviderMetricsSnapshot struct {
 	EmptyAcquireCount       int64         `json:"empty_acquire_count"`
 	EmptyAcquireWaitTime    time.Duration `json:"empty_acquire_wait_time"`
 	CanceledAcquireCount    int64         `json:"canceled_acquire_count"`
-	
+
 	// Connection-level aggregated metrics
-	TotalBytesDownloaded   int64   `json:"total_bytes_downloaded"`
-	TotalBytesUploaded     int64   `json:"total_bytes_uploaded"`
-	TotalCommands          int64   `json:"total_commands"`
-	TotalCommandErrors     int64   `json:"total_command_errors"`
-	SuccessRate            float64 `json:"success_rate_percent"`
-	AverageConnectionAge   time.Duration `json:"average_connection_age"`
+	TotalBytesDownloaded int64         `json:"total_bytes_downloaded"`
+	TotalBytesUploaded   int64         `json:"total_bytes_uploaded"`
+	TotalCommands        int64         `json:"total_commands"`
+	TotalCommandErrors   int64         `json:"total_command_errors"`
+	SuccessRate          float64       `json:"success_rate_percent"`
+	AverageConnectionAge time.Duration `json:"average_connection_age"`
+}
+
+type AggregatedMetrics struct {
+	TotalBytesDownloaded int64
+	TotalBytesUploaded   int64
+	TotalCommands        int64
+	TotalCommandErrors   int64
+	SuccessRate          float64
+	AverageConnectionAge time.Duration
 }
 
 // GetSnapshot returns a comprehensive snapshot of all metrics
@@ -322,32 +275,43 @@ type ProviderMetricsSnapshot struct {
 func (m *PoolMetrics) GetSnapshot(pools []*providerPool) PoolMetricsSnapshot {
 	timestamp := time.Now()
 	uptime := m.GetUptime()
-	
-	// Calculate speed metrics
+
+	// Aggregate all connection metrics first to get totals
+	var globalTotalBytesDownloaded, globalTotalBytesUploaded int64
+	var globalTotalCommands, globalTotalCommandErrors int64
+
+	for _, pool := range pools {
+		aggregated := m.aggregateConnectionMetrics(pool)
+		globalTotalBytesDownloaded += aggregated.TotalBytesDownloaded
+		globalTotalBytesUploaded += aggregated.TotalBytesUploaded
+		globalTotalCommands += aggregated.TotalCommands
+		globalTotalCommandErrors += aggregated.TotalCommandErrors
+	}
+
+	// Calculate speed metrics from aggregated connection data
 	uptimeSeconds := uptime.Seconds()
 	var downloadSpeed, uploadSpeed float64
 	if uptimeSeconds > 0 {
-		downloadSpeed = float64(m.GetTotalBytesDownloaded()) / uptimeSeconds
-		uploadSpeed = float64(m.GetTotalBytesUploaded()) / uptimeSeconds
+		downloadSpeed = float64(globalTotalBytesDownloaded) / uptimeSeconds
+		uploadSpeed = float64(globalTotalBytesUploaded) / uptimeSeconds
 	}
-	
-	// Calculate success rates
-	totalCommands := m.GetTotalCommandCount()
+
+	// Calculate success rates from aggregated connection data
 	var commandSuccessRate float64
-	if totalCommands > 0 {
-		commandSuccessRate = float64(totalCommands-m.GetTotalCommandErrors()) / float64(totalCommands) * 100
+	if globalTotalCommands > 0 {
+		commandSuccessRate = float64(globalTotalCommands-globalTotalCommandErrors) / float64(globalTotalCommands) * 100
 	}
-	
+
 	totalOperations := m.GetTotalAcquires()
 	var errorRate float64
 	if totalOperations > 0 {
 		errorRate = float64(m.GetTotalErrors()) / float64(totalOperations) * 100
 	}
-	
+
 	// Aggregate pool utilization
 	var totalAcquired, totalIdle, totalConnections int32
 	providerMetrics := make([]ProviderMetricsSnapshot, 0, len(pools))
-	
+
 	for _, pool := range pools {
 		stat := pool.connectionPool.Stat()
 		providerSnapshot := ProviderMetricsSnapshot{
@@ -366,7 +330,7 @@ func (m *PoolMetrics) GetSnapshot(pools []*providerPool) PoolMetricsSnapshot {
 			EmptyAcquireWaitTime:    stat.EmptyAcquireWaitTime(),
 			CanceledAcquireCount:    stat.CanceledAcquireCount(),
 		}
-		
+
 		// Aggregate connection metrics for this provider
 		aggregatedMetrics := m.aggregateConnectionMetrics(pool)
 		providerSnapshot.TotalBytesDownloaded = aggregatedMetrics.TotalBytesDownloaded
@@ -375,53 +339,46 @@ func (m *PoolMetrics) GetSnapshot(pools []*providerPool) PoolMetricsSnapshot {
 		providerSnapshot.TotalCommandErrors = aggregatedMetrics.TotalCommandErrors
 		providerSnapshot.SuccessRate = aggregatedMetrics.SuccessRate
 		providerSnapshot.AverageConnectionAge = aggregatedMetrics.AverageConnectionAge
-		
+
 		providerMetrics = append(providerMetrics, providerSnapshot)
-		
+
 		// Add to totals
 		totalAcquired += stat.AcquiredResources()
 		totalIdle += stat.IdleResources()
 		totalConnections += stat.TotalResources()
 	}
-	
+
 	return PoolMetricsSnapshot{
-		Timestamp:               timestamp,
-		Uptime:                  uptime,
-		TotalConnectionsCreated: m.GetTotalConnectionsCreated(),
+		Timestamp:                 timestamp,
+		Uptime:                    uptime,
+		TotalConnectionsCreated:   m.GetTotalConnectionsCreated(),
 		TotalConnectionsDestroyed: m.GetTotalConnectionsDestroyed(),
-		ActiveConnections:       m.GetActiveConnections(),
-		TotalAcquires:           m.GetTotalAcquires(),
-		TotalReleases:           m.GetTotalReleases(),
-		AcquiredConnections:     totalAcquired,
-		IdleConnections:         totalIdle,
-		TotalConnections:        totalConnections,
-		TotalBytesDownloaded:    m.GetTotalBytesDownloaded(),
-		TotalBytesUploaded:      m.GetTotalBytesUploaded(),
-		TotalArticlesRetrieved:  m.GetTotalArticlesRetrieved(),
-		TotalArticlesPosted:     m.GetTotalArticlesPosted(),
-		DownloadSpeed:           downloadSpeed,
-		UploadSpeed:             uploadSpeed,
-		TotalCommandCount:       totalCommands,
-		TotalCommandErrors:      m.GetTotalCommandErrors(),
-		CommandSuccessRate:      commandSuccessRate,
-		AverageAcquireWaitTime:  m.GetAverageAcquireWaitTime(),
-		TotalErrors:             m.GetTotalErrors(),
-		TotalRetries:            m.GetTotalRetries(),
-		ErrorRate:               errorRate,
-		ProviderMetrics:         providerMetrics,
+		ActiveConnections:         m.GetActiveConnections(),
+		TotalAcquires:             m.GetTotalAcquires(),
+		TotalReleases:             m.GetTotalReleases(),
+		AcquiredConnections:       totalAcquired,
+		IdleConnections:           totalIdle,
+		TotalConnections:          totalConnections,
+		TotalBytesDownloaded:      globalTotalBytesDownloaded,
+		TotalBytesUploaded:        globalTotalBytesUploaded,
+		TotalArticlesRetrieved:    0, // Will be calculated from connections if needed
+		TotalArticlesPosted:       0, // Will be calculated from connections if needed  
+		DownloadSpeed:             downloadSpeed,
+		UploadSpeed:               uploadSpeed,
+		TotalCommandCount:         globalTotalCommands,
+		TotalCommandErrors:        globalTotalCommandErrors,
+		CommandSuccessRate:        commandSuccessRate,
+		AverageAcquireWaitTime:    m.GetAverageAcquireWaitTime(),
+		TotalErrors:               m.GetTotalErrors(),
+		TotalRetries:              m.GetTotalRetries(),
+		ErrorRate:                 errorRate,
+		ProviderMetrics:           providerMetrics,
 	}
 }
 
 // aggregateConnectionMetrics aggregates metrics from all connections in a provider pool
 // This includes both idle connections and active connections for complete visibility
-func (m *PoolMetrics) aggregateConnectionMetrics(pool *providerPool) struct {
-	TotalBytesDownloaded   int64
-	TotalBytesUploaded     int64
-	TotalCommands          int64
-	TotalCommandErrors     int64
-	SuccessRate            float64
-	AverageConnectionAge   time.Duration
-} {
+func (m *PoolMetrics) aggregateConnectionMetrics(pool *providerPool) AggregatedMetrics {
 	var totalBytesDownloaded, totalBytesUploaded int64
 	var totalCommands, totalCommandErrors int64
 	var totalConnectionAge time.Duration
@@ -435,9 +392,9 @@ func (m *PoolMetrics) aggregateConnectionMetrics(pool *providerPool) struct {
 			res.ReleaseUnused()
 		}
 	}()
-	
+
 	connectionCount += len(idleResources)
-	
+
 	for _, res := range idleResources {
 		conn := res.Value()
 		if conn.nntp != nil {
@@ -472,25 +429,18 @@ func (m *PoolMetrics) aggregateConnectionMetrics(pool *providerPool) struct {
 		}
 		return true // Continue iteration
 	})
-	
+
 	var successRate float64
 	if totalCommands > 0 {
 		successRate = float64(totalCommands-totalCommandErrors) / float64(totalCommands) * 100
 	}
-	
+
 	var averageConnectionAge time.Duration
 	if connectionCount > 0 {
 		averageConnectionAge = totalConnectionAge / time.Duration(connectionCount)
 	}
-	
-	return struct {
-		TotalBytesDownloaded   int64
-		TotalBytesUploaded     int64
-		TotalCommands          int64
-		TotalCommandErrors     int64
-		SuccessRate            float64
-		AverageConnectionAge   time.Duration
-	}{
+
+	return AggregatedMetrics{
 		TotalBytesDownloaded: totalBytesDownloaded,
 		TotalBytesUploaded:   totalBytesUploaded,
 		TotalCommands:        totalCommands,

--- a/metrics.go
+++ b/metrics.go
@@ -573,6 +573,7 @@ func (m *PoolMetrics) calculateRecentSpeeds(pools []*providerPool) (downloadSpee
 func (m *PoolMetrics) calculateRecentSpeedsUncached() (downloadSpeed, uploadSpeed float64) {
 	var recentBytesDownloaded, recentBytesUploaded int64
 	var activeConnectionCount int
+	var timeAggregated int64
 
 	// Use only active connections - zero pool blocking, maximum performance
 	m.activeConnections.Range(func(key, value interface{}) bool {
@@ -587,28 +588,17 @@ func (m *PoolMetrics) calculateRecentSpeedsUncached() (downloadSpeed, uploadSpee
 			snapshot := metrics.GetSnapshot()
 			connectionAge := metrics.GetConnectionAge()
 
-			if connectionAge <= m.speedWindowDuration {
-				// Connection is newer than our time window - count all its bytes
-				recentBytesDownloaded += snapshot.BytesDownloaded
-				recentBytesUploaded += snapshot.BytesUploaded
-			} else {
-				// Connection is older than window - estimate recent activity
-				// Since it's active, we can be generous with the estimation
-				windowRatio := float64(m.speedWindowDuration) / float64(connectionAge)
-				recentBytesDownloaded += int64(float64(snapshot.BytesDownloaded) * windowRatio * 0.8)
-				recentBytesUploaded += int64(float64(snapshot.BytesUploaded) * windowRatio * 0.8)
-			}
+			recentBytesDownloaded += snapshot.BytesDownloaded
+			recentBytesUploaded += snapshot.BytesUploaded
+			timeAggregated += int64(connectionAge.Seconds())
+
 			activeConnectionCount++
 		}
 		return true
 	})
 
-	// Calculate speeds based on active connection activity
-	windowSeconds := m.speedWindowDuration.Seconds()
-	if windowSeconds > 0 && activeConnectionCount > 0 {
-		downloadSpeed = float64(recentBytesDownloaded) / windowSeconds
-		uploadSpeed = float64(recentBytesUploaded) / windowSeconds
-	}
+	downloadSpeed = float64(recentBytesDownloaded) / float64(timeAggregated)
+	uploadSpeed = float64(recentBytesUploaded) / float64(timeAggregated)
 
 	return downloadSpeed, uploadSpeed
 }

--- a/metrics.go
+++ b/metrics.go
@@ -531,8 +531,8 @@ func (m *PoolMetrics) aggregateConnectionMetrics(pool *providerPool) AggregatedM
 		TotalCommandErrors:     totalCommandErrors,
 		SuccessRate:            successRate,
 		AverageConnectionAge:   averageConnectionAge,
-		TotalArticlesRetrieved: 0, // Placeholder, can be calculated from articles if needed
-		TotalArticlesPosted:    0, // Placeholder, can be calculated from articles if
+		TotalArticlesRetrieved: totalArticlesRetrieved,
+		TotalArticlesPosted:    totalArticlesPosted,
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -312,12 +312,14 @@ type ProviderMetricsSnapshot struct {
 	CanceledAcquireCount    int64         `json:"canceled_acquire_count"`
 
 	// Connection-level aggregated metrics
-	TotalBytesDownloaded int64         `json:"total_bytes_downloaded"`
-	TotalBytesUploaded   int64         `json:"total_bytes_uploaded"`
-	TotalCommands        int64         `json:"total_commands"`
-	TotalCommandErrors   int64         `json:"total_command_errors"`
-	SuccessRate          float64       `json:"success_rate_percent"`
-	AverageConnectionAge time.Duration `json:"average_connection_age"`
+	TotalBytesDownloaded   int64         `json:"total_bytes_downloaded"`
+	TotalBytesUploaded     int64         `json:"total_bytes_uploaded"`
+	TotalCommands          int64         `json:"total_commands"`
+	TotalCommandErrors     int64         `json:"total_command_errors"`
+	SuccessRate            float64       `json:"success_rate_percent"`
+	AverageConnectionAge   time.Duration `json:"average_connection_age"`
+	TotalArticlesRetrieved int64         `json:"total_articles_retrieved"`
+	TotalArticlesPosted    int64         `json:"total_articles_posted"`
 }
 
 type AggregatedMetrics struct {
@@ -411,6 +413,8 @@ func (m *PoolMetrics) GetSnapshot(pools []*providerPool) PoolMetricsSnapshot {
 		providerSnapshot.TotalCommandErrors = aggregatedMetrics.TotalCommandErrors
 		providerSnapshot.SuccessRate = aggregatedMetrics.SuccessRate
 		providerSnapshot.AverageConnectionAge = aggregatedMetrics.AverageConnectionAge
+		providerSnapshot.TotalArticlesRetrieved = aggregatedMetrics.TotalArticlesRetrieved
+		providerSnapshot.TotalArticlesPosted = aggregatedMetrics.TotalArticlesPosted
 
 		providerMetrics = append(providerMetrics, providerSnapshot)
 
@@ -433,8 +437,8 @@ func (m *PoolMetrics) GetSnapshot(pools []*providerPool) PoolMetricsSnapshot {
 		TotalConnections:          totalConnections,
 		TotalBytesDownloaded:      globalTotalBytesDownloaded,
 		TotalBytesUploaded:        globalTotalBytesUploaded,
-		TotalArticlesRetrieved:    0,                                   // Will be calculated from connections if needed
-		TotalArticlesPosted:       0,                                   // Will be calculated from connections if needed
+		TotalArticlesRetrieved:    globalArticlesRetrieved,             // Will be calculated from connections if needed
+		TotalArticlesPosted:       globalArticlesPosted,                // Will be calculated from connections if needed
 		DownloadSpeed:             recentDownloadSpeed,                 // Use recent speed (current activity)
 		UploadSpeed:               recentUploadSpeed,                   // Use recent speed (current activity)
 		HistoricalDownloadSpeed:   historicalDownloadSpeed,             // Historical average since pool start

--- a/metrics.go
+++ b/metrics.go
@@ -509,6 +509,8 @@ func (m *PoolMetrics) aggregateConnectionMetrics(pool *providerPool) AggregatedM
 			totalCommands += snapshot.TotalCommands
 			totalCommandErrors += snapshot.CommandErrors
 			totalConnectionAge += metrics.GetConnectionAge()
+			totalArticlesRetrieved += snapshot.ArticlesRetrieved
+			totalArticlesPosted += snapshot.ArticlesPosted
 			connectionCount++
 		}
 		return true // Continue iteration

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -445,24 +445,6 @@ func TestPoolMetrics_ActiveOnlySpeedCalculation(t *testing.T) {
 	assert.Equal(t, float64(0), uploadSpeed)
 }
 
-func TestPoolMetrics_NoPoolInterference(t *testing.T) {
-	metrics := NewPoolMetrics()
-	
-	// Verify that speed calculation doesn't require or use pool parameters
-	// This test ensures complete isolation from pool operations
-	
-	start := time.Now()
-	for i := 0; i < 1000; i++ {
-		downloadSpeed, uploadSpeed := metrics.calculateRecentSpeedsUncached()
-		assert.Equal(t, float64(0), downloadSpeed) // No active connections = 0 speed
-		assert.Equal(t, float64(0), uploadSpeed)
-	}
-	elapsed := time.Since(start)
-	
-	// Should be extremely fast with no pool operations
-	assert.True(t, elapsed < 5*time.Millisecond, "1000 calculations took %v", elapsed)
-}
-
 // Benchmark tests to ensure minimal performance overhead
 func BenchmarkPoolMetrics_RecordConnectionCreated(b *testing.B) {
 	metrics := NewPoolMetrics()

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -77,7 +77,7 @@ func TestPoolMetrics_TrafficMetrics(t *testing.T) {
 	assert.Equal(t, int64(0), metrics.GetTotalConnectionsCreated())
 	assert.Equal(t, int64(0), metrics.GetTotalAcquires())
 	assert.Equal(t, int64(0), metrics.GetTotalErrors())
-	
+
 	// Connection operations should not be tracked at pool level anymore
 	// Traffic metrics will come from connection aggregation in GetSnapshot()
 }
@@ -91,7 +91,7 @@ func TestPoolMetrics_CommandMetrics(t *testing.T) {
 	assert.Equal(t, int64(0), metrics.GetTotalConnectionsCreated())
 	assert.Equal(t, int64(0), metrics.GetTotalAcquires())
 	assert.Equal(t, int64(0), metrics.GetTotalErrors())
-	
+
 	// Command metrics will come from connection aggregation in GetSnapshot()
 }
 
@@ -183,46 +183,46 @@ func TestPoolMetrics_SnapshotCalculations(t *testing.T) {
 	snapshot := metrics.GetSnapshot(nil)
 
 	// Verify calculated fields
-	assert.Equal(t, float64(0), snapshot.DownloadSpeed)            // No connection data = 0
-	assert.Equal(t, float64(0), snapshot.UploadSpeed)              // No connection data = 0
-	assert.Equal(t, float64(0), snapshot.HistoricalDownloadSpeed)  // No connection data = 0
-	assert.Equal(t, float64(0), snapshot.HistoricalUploadSpeed)    // No connection data = 0
-	assert.Equal(t, float64(0), snapshot.CommandSuccessRate)       // No connection data = 0
-	assert.Equal(t, float64(100), snapshot.ErrorRate)              // 1 error out of 1 acquire = 100%
-	assert.Equal(t, int64(0), snapshot.TotalBytesDownloaded)       // No connection data = 0
-	assert.Equal(t, int64(0), snapshot.TotalBytesUploaded)         // No connection data = 0
-	assert.Equal(t, 60.0, snapshot.SpeedCalculationWindow)         // Default 60 second window
+	assert.Equal(t, float64(0), snapshot.DownloadSpeed)           // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.UploadSpeed)             // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.HistoricalDownloadSpeed) // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.HistoricalUploadSpeed)   // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.CommandSuccessRate)      // No connection data = 0
+	assert.Equal(t, float64(100), snapshot.ErrorRate)             // 1 error out of 1 acquire = 100%
+	assert.Equal(t, int64(0), snapshot.TotalBytesDownloaded)      // No connection data = 0
+	assert.Equal(t, int64(0), snapshot.TotalBytesUploaded)        // No connection data = 0
+	assert.Equal(t, 60.0, snapshot.SpeedCalculationWindow)        // Default 60 second window
 }
 
 func TestPoolMetrics_SpeedCalculationWindow(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Test default window
 	assert.Equal(t, 60*time.Second, metrics.speedWindowDuration)
-	
+
 	// Test setting custom window
 	metrics.SetSpeedWindowDuration(30 * time.Second)
 	assert.Equal(t, 30*time.Second, metrics.speedWindowDuration)
-	
+
 	// Test invalid duration defaults to 60 seconds
 	metrics.SetSpeedWindowDuration(-5 * time.Second)
 	assert.Equal(t, 60*time.Second, metrics.speedWindowDuration)
-	
+
 	metrics.SetSpeedWindowDuration(0)
 	assert.Equal(t, 60*time.Second, metrics.speedWindowDuration)
 }
 
 func TestPoolMetrics_RecentSpeedCalculation(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Set a short window for testing
 	metrics.SetSpeedWindowDuration(5 * time.Second)
-	
+
 	// Test with no pools - should return 0 speed
 	downloadSpeed, uploadSpeed := metrics.calculateRecentSpeeds(nil)
 	assert.Equal(t, float64(0), downloadSpeed)
 	assert.Equal(t, float64(0), uploadSpeed)
-	
+
 	// Test with empty pools slice
 	emptyPools := []*providerPool{}
 	downloadSpeed, uploadSpeed = metrics.calculateRecentSpeeds(emptyPools)
@@ -232,22 +232,22 @@ func TestPoolMetrics_RecentSpeedCalculation(t *testing.T) {
 
 func TestPoolMetrics_SnapshotSpeedFields(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Set a custom window duration
 	metrics.SetSpeedWindowDuration(30 * time.Second)
-	
+
 	// Wait a bit for measurable uptime
 	time.Sleep(10 * time.Millisecond)
-	
+
 	snapshot := metrics.GetSnapshot(nil)
-	
+
 	// Verify new speed fields are present and correct
-	assert.Equal(t, float64(0), snapshot.DownloadSpeed)              // Recent speed
-	assert.Equal(t, float64(0), snapshot.UploadSpeed)                // Recent speed  
-	assert.Equal(t, float64(0), snapshot.HistoricalDownloadSpeed)    // Historical average
-	assert.Equal(t, float64(0), snapshot.HistoricalUploadSpeed)      // Historical average
-	assert.Equal(t, 30.0, snapshot.SpeedCalculationWindow)           // Custom window duration
-	
+	assert.Equal(t, float64(0), snapshot.DownloadSpeed)           // Recent speed
+	assert.Equal(t, float64(0), snapshot.UploadSpeed)             // Recent speed
+	assert.Equal(t, float64(0), snapshot.HistoricalDownloadSpeed) // Historical average
+	assert.Equal(t, float64(0), snapshot.HistoricalUploadSpeed)   // Historical average
+	assert.Equal(t, 30.0, snapshot.SpeedCalculationWindow)        // Custom window duration
+
 	// Verify timestamp and uptime are still working
 	assert.True(t, snapshot.Timestamp.After(time.Now().Add(-1*time.Second)))
 	assert.True(t, snapshot.Uptime > 10*time.Millisecond)
@@ -256,27 +256,27 @@ func TestPoolMetrics_SnapshotSpeedFields(t *testing.T) {
 
 func TestPoolMetrics_SpeedFieldsInSnapshot(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Add some pool-level activity to ensure uptime calculation works
 	metrics.RecordAcquire()
 	metrics.RecordConnectionCreated()
-	
+
 	// Wait to ensure measurable uptime
 	time.Sleep(20 * time.Millisecond)
-	
+
 	snapshot := metrics.GetSnapshot(nil)
-	
+
 	// Should have both recent and historical speeds (both 0 with no connections)
 	assert.Equal(t, float64(0), snapshot.DownloadSpeed)
-	assert.Equal(t, float64(0), snapshot.UploadSpeed) 
+	assert.Equal(t, float64(0), snapshot.UploadSpeed)
 	assert.Equal(t, float64(0), snapshot.HistoricalDownloadSpeed)
 	assert.Equal(t, float64(0), snapshot.HistoricalUploadSpeed)
-	
+
 	// Should have speed calculation window and cache info
 	assert.Equal(t, 60.0, snapshot.SpeedCalculationWindow)
-	assert.Equal(t, 5.0, snapshot.SpeedCacheDuration)              // Default 5 second cache
-	assert.True(t, snapshot.SpeedCacheAge >= 0)                    // Cache age should be non-negative
-	
+	assert.Equal(t, 5.0, snapshot.SpeedCacheDuration) // Default 5 second cache
+	assert.True(t, snapshot.SpeedCacheAge >= 0)       // Cache age should be non-negative
+
 	// Other metrics should still work
 	assert.Equal(t, int64(1), snapshot.TotalAcquires)
 	assert.Equal(t, int64(1), snapshot.TotalConnectionsCreated)
@@ -285,27 +285,27 @@ func TestPoolMetrics_SpeedFieldsInSnapshot(t *testing.T) {
 
 func TestPoolMetrics_CachedSpeedCalculation(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Set short cache duration for testing
 	metrics.SetSpeedCacheDuration(100 * time.Millisecond)
-	
+
 	// First call should calculate and cache
 	downloadSpeed1, uploadSpeed1 := metrics.calculateRecentSpeeds(nil)
 	assert.Equal(t, float64(0), downloadSpeed1)
 	assert.Equal(t, float64(0), uploadSpeed1)
-	
+
 	// Second call immediately after should return cached values
 	start := time.Now()
 	downloadSpeed2, uploadSpeed2 := metrics.calculateRecentSpeeds(nil)
 	elapsed := time.Since(start)
-	
+
 	assert.Equal(t, downloadSpeed1, downloadSpeed2)
 	assert.Equal(t, uploadSpeed1, uploadSpeed2)
 	assert.True(t, elapsed < 50*time.Microsecond) // Should be very fast (cached)
-	
+
 	// Wait for cache to expire
 	time.Sleep(150 * time.Millisecond)
-	
+
 	// Third call should recalculate
 	downloadSpeed3, uploadSpeed3 := metrics.calculateRecentSpeeds(nil)
 	assert.Equal(t, float64(0), downloadSpeed3) // Still 0 with no connections
@@ -314,34 +314,34 @@ func TestPoolMetrics_CachedSpeedCalculation(t *testing.T) {
 
 func TestPoolMetrics_SpeedCacheConfiguration(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Test default cache duration
 	assert.Equal(t, 5*time.Second, metrics.getSpeedCacheDuration())
-	
+
 	// Test setting cache duration
 	metrics.SetSpeedCacheDuration(10 * time.Second)
 	assert.Equal(t, 10*time.Second, metrics.getSpeedCacheDuration())
-	
+
 	// Test invalid duration defaults to 5 seconds
 	metrics.SetSpeedCacheDuration(-1 * time.Second)
 	assert.Equal(t, 5*time.Second, metrics.getSpeedCacheDuration())
-	
+
 	metrics.SetSpeedCacheDuration(0)
 	assert.Equal(t, 5*time.Second, metrics.getSpeedCacheDuration())
 }
 
 func TestPoolMetrics_SpeedCacheAge(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Initially no cache, age should be 0
 	assert.Equal(t, time.Duration(0), metrics.getSpeedCacheAge())
-	
+
 	// After first calculation, should have some age
 	metrics.calculateRecentSpeeds(nil)
 	age1 := metrics.getSpeedCacheAge()
 	assert.True(t, age1 >= 0)
 	assert.True(t, age1 < 10*time.Millisecond)
-	
+
 	// Wait a bit and check age increased
 	time.Sleep(10 * time.Millisecond)
 	age2 := metrics.getSpeedCacheAge()
@@ -351,22 +351,22 @@ func TestPoolMetrics_SpeedCacheAge(t *testing.T) {
 
 func TestPoolMetrics_SnapshotCacheFields(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Set custom cache duration
 	metrics.SetSpeedCacheDuration(3 * time.Second)
-	
+
 	// Get snapshot (this will trigger speed calculation)
 	snapshot := metrics.GetSnapshot(nil)
-	
+
 	// Verify cache fields are populated
 	assert.Equal(t, 3.0, snapshot.SpeedCacheDuration)
 	assert.True(t, snapshot.SpeedCacheAge >= 0)
 	assert.True(t, snapshot.SpeedCacheAge < 1.0) // Should be very recent
-	
+
 	// Wait a bit and get another snapshot
 	time.Sleep(50 * time.Millisecond)
 	snapshot2 := metrics.GetSnapshot(nil)
-	
+
 	// Cache age should have increased (cached values used)
 	assert.True(t, snapshot2.SpeedCacheAge > snapshot.SpeedCacheAge)
 	assert.True(t, snapshot2.SpeedCacheAge >= 0.05) // At least 50ms old
@@ -374,25 +374,25 @@ func TestPoolMetrics_SnapshotCacheFields(t *testing.T) {
 
 func TestPoolMetrics_NonBlockingSpeedCalculation(t *testing.T) {
 	metrics := NewPoolMetrics()
-	
+
 	// Test that speed calculation doesn't panic with nil pools
 	downloadSpeed, uploadSpeed := metrics.calculateRecentSpeeds(nil)
 	assert.Equal(t, float64(0), downloadSpeed)
 	assert.Equal(t, float64(0), uploadSpeed)
-	
+
 	// Test with empty pool slice
 	emptyPools := []*providerPool{}
 	downloadSpeed, uploadSpeed = metrics.calculateRecentSpeeds(emptyPools)
 	assert.Equal(t, float64(0), downloadSpeed)
 	assert.Equal(t, float64(0), uploadSpeed)
-	
+
 	// Test performance - should be fast even when called repeatedly
 	start := time.Now()
 	for i := 0; i < 100; i++ {
 		metrics.calculateRecentSpeeds(nil)
 	}
 	elapsed := time.Since(start)
-	
+
 	// Should be very fast due to caching
 	assert.True(t, elapsed < 10*time.Millisecond, "100 cached calls took %v", elapsed)
 }
@@ -402,65 +402,47 @@ func TestPoolMetrics_ActiveOnlySpeedCalculation(t *testing.T) {
 	defer ctrl.Finish()
 
 	metrics := NewPoolMetrics()
-	
+
 	// Test with no active connections - should return 0
 	downloadSpeed, uploadSpeed := metrics.calculateRecentSpeedsUncached()
 	assert.Equal(t, float64(0), downloadSpeed)
 	assert.Equal(t, float64(0), uploadSpeed)
-	
+
 	// Add mock active connections
 	mockConn1 := nntpcli.NewMockConnection(ctrl)
 	mockConn2 := nntpcli.NewMockConnection(ctrl)
-	
+
 	mockMetrics1 := nntpcli.NewMetrics()
 	mockMetrics2 := nntpcli.NewMetrics()
-	
+
 	mockConn1.EXPECT().GetMetrics().Return(mockMetrics1).AnyTimes()
 	mockConn2.EXPECT().GetMetrics().Return(mockMetrics2).AnyTimes()
-	
+
 	// Simulate some activity
 	mockMetrics1.RecordDownload(1000)
 	mockMetrics1.RecordUpload(500)
 	mockMetrics2.RecordDownload(2000)
 	mockMetrics2.RecordUpload(800)
-	
+
 	// Register as active connections
 	metrics.RegisterActiveConnection("conn1", mockConn1)
 	metrics.RegisterActiveConnection("conn2", mockConn2)
-	
+
 	// Calculate speed based on active connections only
 	downloadSpeed, uploadSpeed = metrics.calculateRecentSpeedsUncached()
-	
+
 	// Should have non-zero speeds based on active connections
 	assert.True(t, downloadSpeed > 0, "Download speed should be > 0 with active connections")
 	assert.True(t, uploadSpeed > 0, "Upload speed should be > 0 with active connections")
-	
+
 	// Unregister connections
 	metrics.UnregisterActiveConnection("conn1")
 	metrics.UnregisterActiveConnection("conn2")
-	
+
 	// Should return to 0 with no active connections
 	downloadSpeed, uploadSpeed = metrics.calculateRecentSpeedsUncached()
 	assert.Equal(t, float64(0), downloadSpeed)
 	assert.Equal(t, float64(0), uploadSpeed)
-}
-
-func TestPoolMetrics_NoPoolInterference(t *testing.T) {
-	metrics := NewPoolMetrics()
-	
-	// Verify that speed calculation doesn't require or use pool parameters
-	// This test ensures complete isolation from pool operations
-	
-	start := time.Now()
-	for i := 0; i < 1000; i++ {
-		downloadSpeed, uploadSpeed := metrics.calculateRecentSpeedsUncached()
-		assert.Equal(t, float64(0), downloadSpeed) // No active connections = 0 speed
-		assert.Equal(t, float64(0), uploadSpeed)
-	}
-	elapsed := time.Since(start)
-	
-	// Should be extremely fast with no pool operations
-	assert.True(t, elapsed < 5*time.Millisecond, "1000 calculations took %v", elapsed)
 }
 
 // Benchmark tests to ensure minimal performance overhead
@@ -692,7 +674,7 @@ func BenchmarkPoolMetrics_GetActiveConnectionMetrics(b *testing.B) {
 
 func BenchmarkPoolMetrics_CalculateRecentSpeeds(b *testing.B) {
 	metrics := NewPoolMetrics()
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = metrics.calculateRecentSpeeds(nil)
@@ -701,10 +683,10 @@ func BenchmarkPoolMetrics_CalculateRecentSpeeds(b *testing.B) {
 
 func BenchmarkPoolMetrics_CalculateRecentSpeedsUncached(b *testing.B) {
 	metrics := NewPoolMetrics()
-	
+
 	// Set cache duration to 0 to force recalculation every time
 	metrics.SetSpeedCacheDuration(1 * time.Nanosecond)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = metrics.calculateRecentSpeeds(nil)
@@ -713,11 +695,11 @@ func BenchmarkPoolMetrics_CalculateRecentSpeedsUncached(b *testing.B) {
 
 func BenchmarkPoolMetrics_GetSnapshotWithSpeedCalculation(b *testing.B) {
 	metrics := NewPoolMetrics()
-	
+
 	// Add some basic metrics to ensure snapshot calculation works
 	metrics.RecordConnectionCreated()
 	metrics.RecordAcquire()
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = metrics.GetSnapshot(nil)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -183,12 +183,218 @@ func TestPoolMetrics_SnapshotCalculations(t *testing.T) {
 	snapshot := metrics.GetSnapshot(nil)
 
 	// Verify calculated fields
-	assert.Equal(t, float64(0), snapshot.DownloadSpeed)        // No connection data = 0
-	assert.Equal(t, float64(0), snapshot.UploadSpeed)          // No connection data = 0
-	assert.Equal(t, float64(0), snapshot.CommandSuccessRate)   // No connection data = 0
-	assert.Equal(t, float64(100), snapshot.ErrorRate)          // 1 error out of 1 acquire = 100%
-	assert.Equal(t, int64(0), snapshot.TotalBytesDownloaded)   // No connection data = 0
-	assert.Equal(t, int64(0), snapshot.TotalBytesUploaded)     // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.DownloadSpeed)            // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.UploadSpeed)              // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.HistoricalDownloadSpeed)  // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.HistoricalUploadSpeed)    // No connection data = 0
+	assert.Equal(t, float64(0), snapshot.CommandSuccessRate)       // No connection data = 0
+	assert.Equal(t, float64(100), snapshot.ErrorRate)              // 1 error out of 1 acquire = 100%
+	assert.Equal(t, int64(0), snapshot.TotalBytesDownloaded)       // No connection data = 0
+	assert.Equal(t, int64(0), snapshot.TotalBytesUploaded)         // No connection data = 0
+	assert.Equal(t, 60.0, snapshot.SpeedCalculationWindow)         // Default 60 second window
+}
+
+func TestPoolMetrics_SpeedCalculationWindow(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Test default window
+	assert.Equal(t, 60*time.Second, metrics.speedWindowDuration)
+	
+	// Test setting custom window
+	metrics.SetSpeedWindowDuration(30 * time.Second)
+	assert.Equal(t, 30*time.Second, metrics.speedWindowDuration)
+	
+	// Test invalid duration defaults to 60 seconds
+	metrics.SetSpeedWindowDuration(-5 * time.Second)
+	assert.Equal(t, 60*time.Second, metrics.speedWindowDuration)
+	
+	metrics.SetSpeedWindowDuration(0)
+	assert.Equal(t, 60*time.Second, metrics.speedWindowDuration)
+}
+
+func TestPoolMetrics_RecentSpeedCalculation(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Set a short window for testing
+	metrics.SetSpeedWindowDuration(5 * time.Second)
+	
+	// Test with no pools - should return 0 speed
+	downloadSpeed, uploadSpeed := metrics.calculateRecentSpeeds(nil)
+	assert.Equal(t, float64(0), downloadSpeed)
+	assert.Equal(t, float64(0), uploadSpeed)
+	
+	// Test with empty pools slice
+	emptyPools := []*providerPool{}
+	downloadSpeed, uploadSpeed = metrics.calculateRecentSpeeds(emptyPools)
+	assert.Equal(t, float64(0), downloadSpeed)
+	assert.Equal(t, float64(0), uploadSpeed)
+}
+
+func TestPoolMetrics_SnapshotSpeedFields(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Set a custom window duration
+	metrics.SetSpeedWindowDuration(30 * time.Second)
+	
+	// Wait a bit for measurable uptime
+	time.Sleep(10 * time.Millisecond)
+	
+	snapshot := metrics.GetSnapshot(nil)
+	
+	// Verify new speed fields are present and correct
+	assert.Equal(t, float64(0), snapshot.DownloadSpeed)              // Recent speed
+	assert.Equal(t, float64(0), snapshot.UploadSpeed)                // Recent speed  
+	assert.Equal(t, float64(0), snapshot.HistoricalDownloadSpeed)    // Historical average
+	assert.Equal(t, float64(0), snapshot.HistoricalUploadSpeed)      // Historical average
+	assert.Equal(t, 30.0, snapshot.SpeedCalculationWindow)           // Custom window duration
+	
+	// Verify timestamp and uptime are still working
+	assert.True(t, snapshot.Timestamp.After(time.Now().Add(-1*time.Second)))
+	assert.True(t, snapshot.Uptime > 10*time.Millisecond)
+	assert.True(t, snapshot.Uptime < 1*time.Second)
+}
+
+func TestPoolMetrics_SpeedFieldsInSnapshot(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Add some pool-level activity to ensure uptime calculation works
+	metrics.RecordAcquire()
+	metrics.RecordConnectionCreated()
+	
+	// Wait to ensure measurable uptime
+	time.Sleep(20 * time.Millisecond)
+	
+	snapshot := metrics.GetSnapshot(nil)
+	
+	// Should have both recent and historical speeds (both 0 with no connections)
+	assert.Equal(t, float64(0), snapshot.DownloadSpeed)
+	assert.Equal(t, float64(0), snapshot.UploadSpeed) 
+	assert.Equal(t, float64(0), snapshot.HistoricalDownloadSpeed)
+	assert.Equal(t, float64(0), snapshot.HistoricalUploadSpeed)
+	
+	// Should have speed calculation window and cache info
+	assert.Equal(t, 60.0, snapshot.SpeedCalculationWindow)
+	assert.Equal(t, 5.0, snapshot.SpeedCacheDuration)              // Default 5 second cache
+	assert.True(t, snapshot.SpeedCacheAge >= 0)                    // Cache age should be non-negative
+	
+	// Other metrics should still work
+	assert.Equal(t, int64(1), snapshot.TotalAcquires)
+	assert.Equal(t, int64(1), snapshot.TotalConnectionsCreated)
+	assert.True(t, snapshot.Uptime > 20*time.Millisecond)
+}
+
+func TestPoolMetrics_CachedSpeedCalculation(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Set short cache duration for testing
+	metrics.SetSpeedCacheDuration(100 * time.Millisecond)
+	
+	// First call should calculate and cache
+	downloadSpeed1, uploadSpeed1 := metrics.calculateRecentSpeeds(nil)
+	assert.Equal(t, float64(0), downloadSpeed1)
+	assert.Equal(t, float64(0), uploadSpeed1)
+	
+	// Second call immediately after should return cached values
+	start := time.Now()
+	downloadSpeed2, uploadSpeed2 := metrics.calculateRecentSpeeds(nil)
+	elapsed := time.Since(start)
+	
+	assert.Equal(t, downloadSpeed1, downloadSpeed2)
+	assert.Equal(t, uploadSpeed1, uploadSpeed2)
+	assert.True(t, elapsed < 50*time.Microsecond) // Should be very fast (cached)
+	
+	// Wait for cache to expire
+	time.Sleep(150 * time.Millisecond)
+	
+	// Third call should recalculate
+	downloadSpeed3, uploadSpeed3 := metrics.calculateRecentSpeeds(nil)
+	assert.Equal(t, float64(0), downloadSpeed3) // Still 0 with no connections
+	assert.Equal(t, float64(0), uploadSpeed3)
+}
+
+func TestPoolMetrics_SpeedCacheConfiguration(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Test default cache duration
+	assert.Equal(t, 5*time.Second, metrics.getSpeedCacheDuration())
+	
+	// Test setting cache duration
+	metrics.SetSpeedCacheDuration(10 * time.Second)
+	assert.Equal(t, 10*time.Second, metrics.getSpeedCacheDuration())
+	
+	// Test invalid duration defaults to 5 seconds
+	metrics.SetSpeedCacheDuration(-1 * time.Second)
+	assert.Equal(t, 5*time.Second, metrics.getSpeedCacheDuration())
+	
+	metrics.SetSpeedCacheDuration(0)
+	assert.Equal(t, 5*time.Second, metrics.getSpeedCacheDuration())
+}
+
+func TestPoolMetrics_SpeedCacheAge(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Initially no cache, age should be 0
+	assert.Equal(t, time.Duration(0), metrics.getSpeedCacheAge())
+	
+	// After first calculation, should have some age
+	metrics.calculateRecentSpeeds(nil)
+	age1 := metrics.getSpeedCacheAge()
+	assert.True(t, age1 >= 0)
+	assert.True(t, age1 < 10*time.Millisecond)
+	
+	// Wait a bit and check age increased
+	time.Sleep(10 * time.Millisecond)
+	age2 := metrics.getSpeedCacheAge()
+	assert.True(t, age2 > age1)
+	assert.True(t, age2 >= 10*time.Millisecond)
+}
+
+func TestPoolMetrics_SnapshotCacheFields(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Set custom cache duration
+	metrics.SetSpeedCacheDuration(3 * time.Second)
+	
+	// Get snapshot (this will trigger speed calculation)
+	snapshot := metrics.GetSnapshot(nil)
+	
+	// Verify cache fields are populated
+	assert.Equal(t, 3.0, snapshot.SpeedCacheDuration)
+	assert.True(t, snapshot.SpeedCacheAge >= 0)
+	assert.True(t, snapshot.SpeedCacheAge < 1.0) // Should be very recent
+	
+	// Wait a bit and get another snapshot
+	time.Sleep(50 * time.Millisecond)
+	snapshot2 := metrics.GetSnapshot(nil)
+	
+	// Cache age should have increased (cached values used)
+	assert.True(t, snapshot2.SpeedCacheAge > snapshot.SpeedCacheAge)
+	assert.True(t, snapshot2.SpeedCacheAge >= 0.05) // At least 50ms old
+}
+
+func TestPoolMetrics_NonBlockingSpeedCalculation(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Test that speed calculation doesn't panic with nil pools
+	downloadSpeed, uploadSpeed := metrics.calculateRecentSpeeds(nil)
+	assert.Equal(t, float64(0), downloadSpeed)
+	assert.Equal(t, float64(0), uploadSpeed)
+	
+	// Test with empty pool slice
+	emptyPools := []*providerPool{}
+	downloadSpeed, uploadSpeed = metrics.calculateRecentSpeeds(emptyPools)
+	assert.Equal(t, float64(0), downloadSpeed)
+	assert.Equal(t, float64(0), uploadSpeed)
+	
+	// Test performance - should be fast even when called repeatedly
+	start := time.Now()
+	for i := 0; i < 100; i++ {
+		metrics.calculateRecentSpeeds(nil)
+	}
+	elapsed := time.Since(start)
+	
+	// Should be very fast due to caching
+	assert.True(t, elapsed < 10*time.Millisecond, "100 cached calls took %v", elapsed)
 }
 
 // Benchmark tests to ensure minimal performance overhead
@@ -415,5 +621,45 @@ func BenchmarkPoolMetrics_GetActiveConnectionMetrics(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = metrics.GetActiveConnectionMetrics()
+	}
+}
+
+func BenchmarkPoolMetrics_CalculateRecentSpeeds(b *testing.B) {
+	metrics := NewPoolMetrics()
+	
+	// Test with empty pools (cached performance)
+	emptyPools := []*providerPool{}
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = metrics.calculateRecentSpeeds(emptyPools)
+	}
+}
+
+func BenchmarkPoolMetrics_CalculateRecentSpeedsUncached(b *testing.B) {
+	metrics := NewPoolMetrics()
+	
+	// Set cache duration to 0 to force recalculation every time
+	metrics.SetSpeedCacheDuration(1 * time.Nanosecond)
+	
+	// Test with empty pools (uncached performance)
+	emptyPools := []*providerPool{}
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = metrics.calculateRecentSpeeds(emptyPools)
+	}
+}
+
+func BenchmarkPoolMetrics_GetSnapshotWithSpeedCalculation(b *testing.B) {
+	metrics := NewPoolMetrics()
+	
+	// Add some basic metrics to ensure snapshot calculation works
+	metrics.RecordConnectionCreated()
+	metrics.RecordAcquire()
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = metrics.GetSnapshot(nil)
 	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -445,6 +445,24 @@ func TestPoolMetrics_ActiveOnlySpeedCalculation(t *testing.T) {
 	assert.Equal(t, float64(0), uploadSpeed)
 }
 
+func TestPoolMetrics_NoPoolInterference(t *testing.T) {
+	metrics := NewPoolMetrics()
+	
+	// Verify that speed calculation doesn't require or use pool parameters
+	// This test ensures complete isolation from pool operations
+	
+	start := time.Now()
+	for i := 0; i < 1000; i++ {
+		downloadSpeed, uploadSpeed := metrics.calculateRecentSpeedsUncached()
+		assert.Equal(t, float64(0), downloadSpeed) // No active connections = 0 speed
+		assert.Equal(t, float64(0), uploadSpeed)
+	}
+	elapsed := time.Since(start)
+	
+	// Should be extremely fast with no pool operations
+	assert.True(t, elapsed < 5*time.Millisecond, "1000 calculations took %v", elapsed)
+}
+
 // Benchmark tests to ensure minimal performance overhead
 func BenchmarkPoolMetrics_RecordConnectionCreated(b *testing.B) {
 	metrics := NewPoolMetrics()


### PR DESCRIPTION
This pull request introduces significant changes to the metrics system of the connection pool, focusing on improving performance, accuracy, and flexibility. Key updates include removing redundant metrics tracking, adding support for speed calculations with caching, and refactoring the snapshot and aggregation logic to provide more comprehensive and efficient metrics.

### Metrics System Refactor and Enhancements:

* Removed redundant metrics tracking (e.g., `totalBytesDownloaded`, `totalArticlesRetrieved`) and associated methods from `PoolMetrics`. These metrics are now calculated dynamically or aggregated from connection data. (`metrics.go`: [[1]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L22-R55) [[2]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L73-L102) [[3]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L132-R165)
* Introduced a `speedCache` structure in `PoolMetrics` to cache speed calculations, reducing performance overhead. Added methods to configure the speed window and cache duration (`SetSpeedWindowDuration`, `SetSpeedCacheDuration`). (`metrics.go`: [[1]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L22-R55) [[2]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L132-R165)
* Added new speed metrics (`DownloadSpeed`, `UploadSpeed`, `HistoricalDownloadSpeed`, `HistoricalUploadSpeed`) in `PoolMetricsSnapshot`, along with metadata about the speed calculation window and cache. (`metrics.go`: [[1]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L274-R278) [[2]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L398-R446)
* Implemented methods for calculating recent upload/download speeds (`calculateRecentSpeeds`, `calculateRecentSpeedsUncached`) using active connections and caching results. (`metrics.go`: [metrics.goL486-R607](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L486-R607))

### Connection Pool Code Simplification:

* Removed calls to outdated metrics recording methods (`RecordCommand`, `RecordBytesDownloaded`, etc.) across connection pool methods (`Body`, `BodyReader`, `Post`, `Stat`). These are no longer necessary due to the new aggregation-based approach. (`connection_pool.go`: [[1]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL460-L467) [[2]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL611-L616) [[3]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL734-L740) [[4]](diffhunk://#diff-bfa8cf4f87505486ddbb24c834ee2e5c4dbd8ace4e1f617406040b863130750dL879-L884)

### Example Updates:

* Updated the `ExampleMetricsUsage` function to demonstrate the new speed calculation configuration and usage of metrics snapshots for traffic data. Removed direct calls to deprecated methods like `GetTotalBytesDownloaded`. (`example_metrics_usage.go`: [[1]](diffhunk://#diff-8aae4de76ddbdb423f756f3aeba1b7ba2e488e81457ea73ecccfbaa63a5a16daL34-R61) [[2]](diffhunk://#diff-8aae4de76ddbdb423f756f3aeba1b7ba2e488e81457ea73ecccfbaa63a5a16daL53-R70)

### Dependency Update:

* Updated the `nntpcli` dependency from version `1.1.0` to `1.1.1` in `go.mod`, likely to support the new metrics functionality. (`go.mod`: [go.modL9-R9](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L9-R9))

These changes modernize the metrics system, making it more efficient and adaptable while simplifying the connection pool's codebase.