### PR TITLE
fix(post): validate headers and fix body terminator to prevent rejections

### DIFF
--- a/client.go
+++ b/client.go
@@ -294,7 +294,10 @@ func (c *Client) PostYenc(ctx context.Context, headers PostHeaders, body io.Read
 		if err = enc.Close(); err != nil {
 			return
 		}
-		_, err = pw.Write([]byte("\r\n.\r\n"))
+		// rapidyenc's Close already terminates the last line with CRLF, so we
+		// only need the dot-line terminator here. Writing "\r\n.\r\n" would
+		// inject a stray blank line before the dot.
+		_, err = pw.Write([]byte(".\r\n"))
 	}()
 
 	respCh := c.sendPost(ctx, pr)

--- a/post.go
+++ b/post.go
@@ -1,10 +1,14 @@
 package nntppool
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"mime"
+	"slices"
 	"sort"
 	"strings"
+	"time"
 )
 
 // PostHeaders holds the structured headers for an NNTP POST command.
@@ -13,31 +17,194 @@ type PostHeaders struct {
 	Subject    string   // required
 	Newsgroups []string // required: list of newsgroups
 	MessageID  string   // recommended: "<unique@domain>"
+	// Date is the article date. If zero, time.Now().UTC() is used at WriteTo time.
+	// The Date header is mandatory per RFC 5536 §3.1.1; many servers reject
+	// articles without it.
+	Date time.Time
 	// Extra holds additional headers (e.g., Organization, X-No-Archive).
+	// Values are written verbatim except for CR/LF rejection (injection guard).
 	Extra map[string][]string
+}
+
+// maxHeaderLineLen is the practical RFC 5322 line-length cap (998 octets
+// excluding CRLF). We fold at a comfortably lower threshold to stay safe
+// across relays.
+const maxHeaderLineLen = 900
+
+// validNewsgroupName matches RFC 5536 §3.1.4 newsgroup name syntax.
+// First character must be alphanumeric; remainder allows letters, digits,
+// and the punctuation characters '.', '+', '_', '-'.
+func isValidNewsgroupName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case (r == '.' || r == '+' || r == '_' || r == '-') && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// containsCRLF returns true if s contains a CR or LF, which is forbidden in
+// header names and values to prevent header injection.
+func containsCRLF(s string) bool {
+	return strings.ContainsAny(s, "\r\n")
+}
+
+// isValidHeaderName checks RFC 5322 §2.2 field-name: printable ASCII except
+// colon and whitespace.
+func isValidHeaderName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < 33 || r > 126 || r == ':' {
+			return false
+		}
+	}
+	return true
+}
+
+// isASCII returns true if s contains only ASCII bytes.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 127 {
+			return false
+		}
+	}
+	return true
+}
+
+// encodeHeaderValue applies RFC 2047 B-encoding when the value contains
+// non-ASCII bytes; otherwise returns the value unchanged.
+func encodeHeaderValue(s string) string {
+	if isASCII(s) {
+		return s
+	}
+	return mime.BEncoding.Encode("utf-8", s)
+}
+
+// foldHeaderLine folds a single header line ("Name: value") at whitespace
+// boundaries so no physical line exceeds maxHeaderLineLen octets, per RFC
+// 5322 §2.2.3. Continuation lines are prefixed with CRLF + TAB.
+func foldHeaderLine(line string) string {
+	if len(line) <= maxHeaderLineLen {
+		return line
+	}
+	var b strings.Builder
+	b.Grow(len(line) + len(line)/maxHeaderLineLen*3)
+	remaining := line
+	for len(remaining) > maxHeaderLineLen {
+		// Find a fold point: the last space or tab within the limit.
+		cut := strings.LastIndexAny(remaining[:maxHeaderLineLen], " \t")
+		if cut <= 0 {
+			// No whitespace found within limit; emit as-is to avoid splitting
+			// a token. Subsequent relays may reject, but this is preferable to
+			// breaking a Message-ID or quoted-printable token.
+			b.WriteString(remaining)
+			return b.String()
+		}
+		b.WriteString(remaining[:cut])
+		b.WriteString("\r\n\t")
+		remaining = strings.TrimLeft(remaining[cut:], " \t")
+	}
+	b.WriteString(remaining)
+	return b.String()
+}
+
+// validate returns nil if the headers are well-formed and safe to write.
+func (h PostHeaders) validate() error {
+	if strings.TrimSpace(h.From) == "" {
+		return errors.New("nntp post: From header is required")
+	}
+	if containsCRLF(h.From) {
+		return errors.New("nntp post: From contains CR/LF")
+	}
+	if strings.TrimSpace(h.Subject) == "" {
+		return errors.New("nntp post: Subject header is required")
+	}
+	if containsCRLF(h.Subject) {
+		return errors.New("nntp post: Subject contains CR/LF")
+	}
+	if len(h.Newsgroups) == 0 {
+		return errors.New("nntp post: at least one newsgroup is required")
+	}
+	if i := slices.IndexFunc(h.Newsgroups, func(g string) bool {
+		return !isValidNewsgroupName(strings.TrimSpace(g))
+	}); i >= 0 {
+		return fmt.Errorf("nntp post: invalid newsgroup name %q", strings.TrimSpace(h.Newsgroups[i]))
+	}
+	if h.MessageID != "" {
+		if containsCRLF(h.MessageID) {
+			return errors.New("nntp post: Message-ID contains CR/LF")
+		}
+		if !strings.HasPrefix(h.MessageID, "<") || !strings.HasSuffix(h.MessageID, ">") ||
+			strings.ContainsAny(h.MessageID, " \t") {
+			return fmt.Errorf("nntp post: malformed Message-ID %q", h.MessageID)
+		}
+	}
+	for k, vs := range h.Extra {
+		if !isValidHeaderName(k) {
+			return fmt.Errorf("nntp post: invalid Extra header name %q", k)
+		}
+		if slices.ContainsFunc(vs, containsCRLF) {
+			return fmt.Errorf("nntp post: Extra header %q value contains CR/LF", k)
+		}
+	}
+	return nil
 }
 
 // WriteTo formats the headers as RFC 5322 and writes them to w,
 // including the blank line separator after headers.
+//
+// Returns an error if any required field is missing, or if any header value
+// contains CR/LF (header-injection guard).
 func (h PostHeaders) WriteTo(w io.Writer) (int64, error) {
+	if err := h.validate(); err != nil {
+		return 0, err
+	}
+
 	var total int64
-	write := func(s string) error {
-		n, err := io.WriteString(w, s)
+	write := func(name, value string) error {
+		line := foldHeaderLine(fmt.Sprintf("%s: %s", name, value))
+		n, err := io.WriteString(w, line+"\r\n")
 		total += int64(n)
 		return err
 	}
 
-	if err := write(fmt.Sprintf("From: %s\r\n", h.From)); err != nil {
+	if err := write("From", encodeHeaderValue(h.From)); err != nil {
 		return total, err
 	}
-	if err := write(fmt.Sprintf("Newsgroups: %s\r\n", strings.Join(h.Newsgroups, ","))); err != nil {
+	// Trim and join newsgroups; validation above guarantees names are well-formed.
+	groups := make([]string, len(h.Newsgroups))
+	for i, g := range h.Newsgroups {
+		groups[i] = strings.TrimSpace(g)
+	}
+	if err := write("Newsgroups", strings.Join(groups, ",")); err != nil {
 		return total, err
 	}
-	if err := write(fmt.Sprintf("Subject: %s\r\n", h.Subject)); err != nil {
+	if err := write("Subject", encodeHeaderValue(h.Subject)); err != nil {
 		return total, err
 	}
 	if h.MessageID != "" {
-		if err := write(fmt.Sprintf("Message-ID: %s\r\n", h.MessageID)); err != nil {
+		if err := write("Message-ID", h.MessageID); err != nil {
+			return total, err
+		}
+	}
+
+	// Date header: only emit if the caller did not supply one via Extra.
+	if _, ok := h.Extra["Date"]; !ok {
+		t := h.Date
+		if t.IsZero() {
+			t = time.Now().UTC()
+		}
+		if err := write("Date", t.UTC().Format(time.RFC1123Z)); err != nil {
 			return total, err
 		}
 	}
@@ -51,7 +218,7 @@ func (h PostHeaders) WriteTo(w io.Writer) (int64, error) {
 		sort.Strings(keys)
 		for _, k := range keys {
 			for _, v := range h.Extra[k] {
-				if err := write(fmt.Sprintf("%s: %s\r\n", k, v)); err != nil {
+				if err := write(k, v); err != nil {
 					return total, err
 				}
 			}
@@ -59,7 +226,9 @@ func (h PostHeaders) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	// Blank line separating headers from body.
-	if err := write("\r\n"); err != nil {
+	n, err := io.WriteString(w, "\r\n")
+	total += int64(n)
+	if err != nil {
 		return total, err
 	}
 

--- a/post_test.go
+++ b/post_test.go
@@ -85,6 +85,153 @@ func TestPostHeaders_WriteTo(t *testing.T) {
 			t.Error("missing X-No-Archive header")
 		}
 	})
+
+	t.Run("auto Date header", func(t *testing.T) {
+		h := PostHeaders{
+			From:       "user@example.com",
+			Subject:    "Test",
+			Newsgroups: []string{"alt.test"},
+		}
+		var buf bytes.Buffer
+		if _, err := h.WriteTo(&buf); err != nil {
+			t.Fatalf("WriteTo error: %v", err)
+		}
+		got := buf.String()
+		if !strings.Contains(got, "Date: ") {
+			t.Error("expected auto-generated Date header")
+		}
+		// RFC1123Z format ends with numeric offset like " +0000".
+		if !strings.Contains(got, " +0000\r\n") && !strings.Contains(got, " -0000\r\n") {
+			t.Errorf("Date header not in RFC1123Z numeric-offset format: %q", got)
+		}
+	})
+
+	t.Run("explicit Date field", func(t *testing.T) {
+		fixed := time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC)
+		h := PostHeaders{
+			From:       "user@example.com",
+			Subject:    "Test",
+			Newsgroups: []string{"alt.test"},
+			Date:       fixed,
+		}
+		var buf bytes.Buffer
+		if _, err := h.WriteTo(&buf); err != nil {
+			t.Fatalf("WriteTo error: %v", err)
+		}
+		want := "Date: " + fixed.Format(time.RFC1123Z) + "\r\n"
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("want %q, got %q", want, buf.String())
+		}
+	})
+
+	t.Run("Date in Extra is not overwritten", func(t *testing.T) {
+		h := PostHeaders{
+			From:       "user@example.com",
+			Subject:    "Test",
+			Newsgroups: []string{"alt.test"},
+			Extra:      map[string][]string{"Date": {"Mon, 02 Jan 2024 15:04:05 +0000"}},
+		}
+		var buf bytes.Buffer
+		if _, err := h.WriteTo(&buf); err != nil {
+			t.Fatalf("WriteTo error: %v", err)
+		}
+		got := buf.String()
+		if strings.Count(got, "Date: ") != 1 {
+			t.Errorf("expected exactly one Date header, got: %q", got)
+		}
+		if !strings.Contains(got, "Date: Mon, 02 Jan 2024 15:04:05 +0000\r\n") {
+			t.Error("caller-supplied Date was overwritten")
+		}
+	})
+
+	t.Run("validation rejects missing required fields", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			h       PostHeaders
+			wantSub string
+		}{
+			{"empty From", PostHeaders{Subject: "s", Newsgroups: []string{"a.b"}}, "From"},
+			{"whitespace From", PostHeaders{From: "   ", Subject: "s", Newsgroups: []string{"a.b"}}, "From"},
+			{"empty Subject", PostHeaders{From: "u@x", Newsgroups: []string{"a.b"}}, "Subject"},
+			{"no newsgroups", PostHeaders{From: "u@x", Subject: "s"}, "newsgroup"},
+			{"empty newsgroup", PostHeaders{From: "u@x", Subject: "s", Newsgroups: []string{""}}, "newsgroup"},
+			{"bad newsgroup char", PostHeaders{From: "u@x", Subject: "s", Newsgroups: []string{"alt test"}}, "newsgroup"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := tc.h.WriteTo(io.Discard)
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantSub) {
+					t.Errorf("error %q does not mention %q", err, tc.wantSub)
+				}
+			})
+		}
+	})
+
+	t.Run("rejects CRLF injection in headers", func(t *testing.T) {
+		cases := []PostHeaders{
+			{From: "u@x\r\nX-Injected: yes", Subject: "s", Newsgroups: []string{"a.b"}},
+			{From: "u@x", Subject: "s\r\nX-Injected: yes", Newsgroups: []string{"a.b"}},
+			{From: "u@x", Subject: "s", Newsgroups: []string{"a.b"}, MessageID: "<id\r\nX-Injected: yes>"},
+			{From: "u@x", Subject: "s", Newsgroups: []string{"a.b"}, Extra: map[string][]string{"X-Foo": {"bar\r\nX-Injected: yes"}}},
+		}
+		for i, h := range cases {
+			if _, err := h.WriteTo(io.Discard); err == nil {
+				t.Errorf("case %d: expected error, got nil", i)
+			}
+		}
+	})
+
+	t.Run("rejects malformed Message-ID", func(t *testing.T) {
+		cases := []string{"no-angle-brackets@x", "<missing-close@x", "missing-open@x>", "<has space@x>"}
+		for _, mid := range cases {
+			h := PostHeaders{From: "u@x", Subject: "s", Newsgroups: []string{"a.b"}, MessageID: mid}
+			if _, err := h.WriteTo(io.Discard); err == nil {
+				t.Errorf("Message-ID %q: expected error, got nil", mid)
+			}
+		}
+	})
+
+	t.Run("RFC 2047 encodes non-ASCII Subject", func(t *testing.T) {
+		h := PostHeaders{
+			From:       "user@example.com",
+			Subject:    "Café résumé",
+			Newsgroups: []string{"alt.test"},
+		}
+		var buf bytes.Buffer
+		if _, err := h.WriteTo(&buf); err != nil {
+			t.Fatalf("WriteTo error: %v", err)
+		}
+		got := buf.String()
+		if !strings.Contains(got, "=?utf-8?b?") && !strings.Contains(got, "=?UTF-8?b?") {
+			t.Errorf("Subject not RFC 2047 encoded: %q", got)
+		}
+	})
+
+	t.Run("folds long Subject", func(t *testing.T) {
+		long := "Subject" + strings.Repeat(" word", 250) // ~1.2K bytes
+		h := PostHeaders{
+			From:       "user@example.com",
+			Subject:    long,
+			Newsgroups: []string{"alt.test"},
+		}
+		var buf bytes.Buffer
+		if _, err := h.WriteTo(&buf); err != nil {
+			t.Fatalf("WriteTo error: %v", err)
+		}
+		got := buf.String()
+		if !strings.Contains(got, "\r\n\t") {
+			t.Error("expected folded continuation \\r\\n\\t in long Subject")
+		}
+		// No physical line should exceed 998 octets.
+		for line := range strings.SplitSeq(got, "\r\n") {
+			if len(line) > 998 {
+				t.Errorf("line exceeds 998 octets: %d", len(line))
+			}
+		}
+	})
 }
 
 // --- POST Client-level integration tests ---


### PR DESCRIPTION
## Summary

Articles produced by `PostYenc` could be rejected (441) by strict Usenet
backends due to missing/non-canonical hygiene compared to mature posters
like [nyuu](https://github.com/animetosho/nyuu). This PR addresses the
header-side and wire-format issues:

- **Validation**: required `From`/`Subject`/`Newsgroups`, RFC 5536 newsgroup
  name syntax, Message-ID shape (`<...>`, no whitespace), CR/LF rejection
  on every header value (injection guard).
- **Auto Date**: emit RFC1123Z (`+0000` numeric offset) when the caller does
  not supply `Date` via `Extra` or the new `Date time.Time` field. Many
  servers reject articles without `Date:` per RFC 5536 §3.1.1.
- **Folding**: header lines >900 octets are folded at whitespace with
  `\r\n\t` (RFC 5322 §2.2.3) so we stay under the 998-octet limit.
- **RFC 2047**: non-ASCII Subject/From are B-encoded as `=?utf-8?b?...?=`.
- **Wire fix**: `client.go` was writing `"\r\n.\r\n"` after `enc.Close()`,
  but rapidyenc already terminates the last line with CRLF — so the wire
  contained a stray blank line before the dot terminator. Now we send just
  `".\r\n"`.

## Test plan

- [x] `make check` (generate + tidy + lint + race tests) — green
- [x] New unit tests in `post_test.go` cover: auto Date, explicit Date,
      Date-in-Extra preserved, all required-field validations, CRLF
      injection rejection, malformed Message-ID rejection, RFC 2047
      encoding, long-Subject folding (no line >998 octets).
- [ ] Manual smoke test against a real provider that previously rejected
      articles to confirm a 240 response (recommend before merging).