### PR TITLE
fix(post): use RFC1123 date format for Usenet compliance

### DIFF
--- a/post.go
+++ b/post.go
@@ -204,7 +204,7 @@ func (h PostHeaders) WriteTo(w io.Writer) (int64, error) {
 		if t.IsZero() {
 			t = time.Now().UTC()
 		}
-		if err := write("Date", t.UTC().Format(time.RFC1123Z)); err != nil {
+		if err := write("Date", t.UTC().Format(time.RFC1123)); err != nil {
 			return total, err
 		}
 	}

--- a/post_test.go
+++ b/post_test.go
@@ -100,9 +100,9 @@ func TestPostHeaders_WriteTo(t *testing.T) {
 		if !strings.Contains(got, "Date: ") {
 			t.Error("expected auto-generated Date header")
 		}
-		// RFC1123Z format ends with numeric offset like " +0000".
-		if !strings.Contains(got, " +0000\r\n") && !strings.Contains(got, " -0000\r\n") {
-			t.Errorf("Date header not in RFC1123Z numeric-offset format: %q", got)
+		// RFC1123 format ends with timezone abbreviation like "UTC".
+		if !strings.Contains(got, " UTC\r\n") {
+			t.Errorf("Date header not in RFC1123 format: %q", got)
 		}
 	})
 
@@ -118,7 +118,7 @@ func TestPostHeaders_WriteTo(t *testing.T) {
 		if _, err := h.WriteTo(&buf); err != nil {
 			t.Fatalf("WriteTo error: %v", err)
 		}
-		want := "Date: " + fixed.Format(time.RFC1123Z) + "\r\n"
+		want := "Date: " + fixed.Format(time.RFC1123) + "\r\n"
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("want %q, got %q", want, buf.String())
 		}


### PR DESCRIPTION
## Summary

- Change `Date:` article header format from `time.RFC1123Z` to `time.RFC1123` in `post.go`
- Update `post_test.go` assertions to match the new format

## Why

The Usenet standard (RFC 5536 §3.1.1) requires the `Date:` header to use **RFC 1123** format, which encodes the timezone as a named abbreviation (e.g. `Mon, 02 Jan 2006 15:04:05 UTC`). The previous code used `time.RFC1123Z`, which produces a numeric offset (e.g. `+0000`) — a format that some NNTP servers reject as non-conformant.

## Test plan

- [ ] `make check` passes (generate + tidy + lint + test-race) ✅
- [ ] Verify a posted article's `Date:` header ends with a timezone abbreviation (`UTC`) rather than a numeric offset (`+0000`)