### PR TITLE
perf(pool): add per-provider attempt timeout to enable real failover

### DIFF
--- a/nntp.go
+++ b/nntp.go
@@ -1567,9 +1567,12 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 	defer close(respCh)
 
 	tryGroup := func(g *providerGroup) (resp Response, ok bool, done bool) {
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, 2*time.Second)
+		defer attemptCancel()
+
 		innerCh := make(chan Response, 1)
 		req := &Request{
-			Ctx:        ctx,
+			Ctx:        attemptCtx,
 			Payload:    payload,
 			RespCh:     innerCh,
 			BodyWriter: bodyWriter,
@@ -1595,8 +1598,8 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			select {
 			case <-c.ctx.Done():
 				return Response{}, false, true
-			case <-ctx.Done():
-				return Response{}, false, true
+			case <-attemptCtx.Done():
+				return Response{}, false, ctx.Err() != nil
 			case <-g.ctx.Done():
 				return Response{}, false, false
 			case coldCh <- req:
@@ -1607,8 +1610,8 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 		case resp, ok = <-innerCh:
 		case <-c.ctx.Done():
 			return Response{}, false, true
-		case <-ctx.Done():
-			return Response{}, false, true
+		case <-attemptCtx.Done():
+			return Response{}, false, ctx.Err() != nil
 		case <-g.ctx.Done():
 			return Response{}, false, false // provider removed; try others
 		}


### PR DESCRIPTION
## Problem

When a provider is slow or has missing articles, the current implementation passes the **global request context** directly into each `tryGroup` call inside `doSendWithRetry`. This means:

1. Provider A is slow / missing segment → context times out or is cancelled
2. `doSendWithRetry` sees `ctx.Done()` → **aborts the entire retry loop**
3. Provider B, C, D... are **never tried** even if they are perfectly healthy

The result: users must manually disable slow/broken providers to avoid imports stalling or failing completely.

## Root Cause

```go
// Before: global ctx passed to every provider attempt
req := &Request{
    Ctx: ctx,  // ← when this times out, ALL providers are abandoned
    ...
}

// Both select cases return done=true, killing the loop
case <-ctx.Done():
    return Response{}, false, true  // ← exits retry loop entirely
```

## Fix

Wrap each individual provider attempt in its own short-lived `attemptCtx` (2 second deadline). Only the **per-provider** attempt is cancelled on timeout; the retry loop continues to the next provider as long as the **caller's** global context still has budget.

```go
// After: per-provider attempt timeout
attemptCtx, attemptCancel := context.WithTimeout(ctx, 2*time.Second)
defer attemptCancel()

req := &Request{
    Ctx: attemptCtx,  // ← only THIS provider's attempt times out
    ...
}

// 'done' now correctly distinguishes per-attempt vs global cancellation
case <-attemptCtx.Done():
    return Response{}, false, ctx.Err() != nil  // only abort if GLOBAL ctx cancelled
```

## Result

With 7 configured providers where one has missing segments:
- **Before**: imports stall/fail, requiring manual provider disabling
- **After**: transparent failover — slow provider attempt times out in 2s, next provider responds in ~100ms, import succeeds

Tested in production with a live Altmount setup running the modified `nntppool` as a local replace dependency before submitting this PR.