### PR TITLE
fix(speedtest): add per-segment timeout to sendToGroup to prevent dead-provider hangs

### DIFF
--- a/speedtest.go
+++ b/speedtest.go
@@ -21,6 +21,14 @@ type SpeedTestOptions struct {
 	OnProgress      func(SpeedTestProgress)
 	NZBFetchTimeout time.Duration // defaults to 30s
 	ProviderName    string        // if set, test only this provider
+	// SegmentTimeout bounds each individual segment fetch when targeting a
+	// specific provider via ProviderName. Without this, a dead or very slow
+	// provider holds the entire speed test hostage until the caller's global
+	// context expires (typically 5 minutes).
+	// Defaults to 30s when ProviderName is set and SegmentTimeout is zero.
+	// Has no effect when ProviderName is empty (sendWithRetry handles its
+	// own per-attempt timeout via the global context).
+	SegmentTimeout time.Duration
 }
 
 // SpeedTestProgress is passed to OnProgress roughly every second.
@@ -133,10 +141,25 @@ func (c *Client) SpeedTest(ctx context.Context, opts SpeedTestOptions) (*SpeedTe
 	// Fan-out: dispatch all segment requests.
 	testStart := time.Now()
 	respChans := make([]<-chan Response, totalSegs)
+
+	// Resolve the per-segment deadline used when targeting a specific provider.
+	// sendWithRetry has its own per-attempt timeout; sendToGroup does not, so we
+	// supply one here to prevent a dead provider from blocking the entire test.
+	segTimeout := opts.SegmentTimeout
+	if targetGroup != nil && segTimeout == 0 {
+		segTimeout = 30 * time.Second
+	}
+
 	for i, seg := range segments {
 		payload := append(append([]byte("BODY <"), seg.MessageID...), ">\r\n"...)
 		if targetGroup != nil {
-			respChans[i] = c.sendToGroup(stCtx, targetGroup, payload, io.Discard)
+			segCtx := stCtx
+			if segTimeout > 0 {
+				var segCancel context.CancelFunc
+				segCtx, segCancel = context.WithTimeout(stCtx, segTimeout)
+				defer segCancel() //nolint:gocritic // deferred inside loop intentionally; all cancelled on test exit
+			}
+			respChans[i] = c.sendToGroup(segCtx, targetGroup, payload, io.Discard)
 		} else {
 			respChans[i] = c.Send(stCtx, payload, io.Discard)
 		}


### PR DESCRIPTION
## Problem

When `SpeedTest` is called with `ProviderName` set, it routes every segment directly to the named provider via `sendToGroup`, bypassing `doSendWithRetry`. Unlike `doSendWithRetry` (which gained a 2s per-attempt `attemptCtx` in v4.11.3 / PR #69), `sendToGroup` passes the **raw caller context** into each `Request`:

```go
req := &Request{
    Ctx: ctx,  // ← global test context, no per-segment bound
    ...
}
```

If the targeted provider is dead, unreachable, or extremely slow, every segment blocks until the caller's global context expires. For the Altmount `POST /providers/:id/speedtest` HTTP handler this is a **5-minute hang** visible to the end user.

## Fix

Resolve a **per-segment deadline** before the fan-out loop and wrap each `sendToGroup` call with a short-lived context:

```go
segTimeout := opts.SegmentTimeout   // 0 → 30s default
if targetGroup != nil && segTimeout == 0 {
    segTimeout = 30 * time.Second
}

for i, seg := range segments {
    ...
    if targetGroup != nil {
        segCtx, segCancel := context.WithTimeout(stCtx, segTimeout)
        defer segCancel()
        respChans[i] = c.sendToGroup(segCtx, targetGroup, payload, io.Discard)
    } else {
        respChans[i] = c.Send(stCtx, payload, io.Discard)  // unchanged
    }
}
```

A new **`SpeedTestOptions.SegmentTimeout`** field lets callers override the default. Setting it to `0` (the zero value) applies the 30s default automatically when `ProviderName` is set.

The normal multi-provider path (`Send` → `sendWithRetry`) is **completely unaffected** — it already has the per-attempt 2s timeout from v4.11.3.

## Behaviour Change

| Scenario | Before | After |
|---|---|---|
| Dead provider, ProviderName set | Hangs for full context TTL (e.g. 5 min) | Times out per segment (default 30s) |
| Slow provider, ProviderName set | Same hang | Bounded per segment |
| ProviderName empty (multi-provider) | Unaffected | Unaffected |
| Custom SegmentTimeout set | N/A (new field) | Uses caller-supplied value |

## Relationship to v4.11.3

PR #69 (merged as v4.11.3) fixed the `doSendWithRetry` path. This PR fixes the complementary `sendToGroup` path used exclusively by `SpeedTest` with per-provider targeting. Together they ensure both code paths are properly bounded.