### PR TITLE
fix(pool): retry same provider on transport-level connection death

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -501,6 +501,61 @@ func TestClient_SendRetryFallbackBackup(t *testing.T) {
 	}
 }
 
+func TestClient_SendRetryConnectionDiedSameProvider(t *testing.T) {
+	// Simulate a stale pooled connection: the first connection the pool opens
+	// dies mid-request (server closes without responding), the next one is
+	// healthy. With a single provider there is no other provider to fall back
+	// to, so the pool must retry on a fresh same-provider connection instead of
+	// returning "all providers exhausted: ... connection died".
+	var connNum atomic.Int32
+
+	factory := func(ctx context.Context) (net.Conn, error) {
+		n := connNum.Add(1)
+		client, server := net.Pipe()
+		go func() {
+			_, _ = server.Write([]byte("200 server ready\r\n"))
+			buf := make([]byte, 4096)
+			if n == 1 {
+				// Stale connection: accept one command, then drop the socket
+				// without responding, mimicking a server-closed idle connection.
+				_, _ = server.Read(buf)
+				_ = server.Close()
+				return
+			}
+			// Healthy connection: answer every STAT with 223.
+			for {
+				if _, err := server.Read(buf); err != nil {
+					return
+				}
+				_, _ = server.Write([]byte("223 1 <id@test> exists\r\n"))
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: factory, Connections: 1, SkipPing: true},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp := <-c.Send(ctx, []byte("STAT <id@test>\r\n"), nil)
+	if resp.Err != nil {
+		t.Fatalf("Send() error = %v, want recovery on a fresh same-provider connection", resp.Err)
+	}
+	if resp.StatusCode != 223 {
+		t.Errorf("StatusCode = %d, want 223 after same-provider reconnect", resp.StatusCode)
+	}
+	if got := connNum.Load(); got < 2 {
+		t.Errorf("expected at least 2 connections (stale + fresh), got %d", got)
+	}
+}
+
 func TestClient_SendRetryAll430(t *testing.T) {
 	makeFactory430 := func() ConnFactory {
 		return func(ctx context.Context) (net.Conn, error) {

--- a/nntp.go
+++ b/nntp.go
@@ -18,6 +18,28 @@ import (
 var ErrMaxConnections = errors.New("nntp: server max connections reached")
 var ErrConnectionDied = errors.New("nntp: connection died")
 
+// isConnectionDeathError reports whether err indicates the underlying
+// connection failed at the transport layer (as opposed to a protocol-level
+// response like 430/502, which is delivered via StatusCode). These are
+// retryable on a fresh connection: an established connection that goes stale
+// surfaces ErrConnectionDied via failOutstanding, while a connection that dies
+// on its bootstrap request surfaces the raw IO error (EOF, closed pipe, reset,
+// timeout). Both mean "this socket is gone — open a new one."
+func isConnectionDeathError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrConnectionDied) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, io.ErrClosedPipe) ||
+		errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
 const (
 	// inflightDrainTimeout is the maximum time to wait for in-flight
 	// responses to complete during idle disconnect.
@@ -42,6 +64,12 @@ const (
 	// defaultHandshakeTimeout caps the TCP dial + TLS handshake phase
 	// to avoid hanging against unresponsive servers.
 	defaultHandshakeTimeout = 10 * time.Second
+
+	// maxConnDiedRetries bounds same-provider retries when a pooled connection
+	// dies mid-request (typically a stale socket the server already closed).
+	// The dead connection has drained by the time the error surfaces, so the
+	// retry uses a fresh connection on the same provider.
+	maxConnDiedRetries = 2
 )
 
 type greetingError struct {
@@ -1618,6 +1646,27 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 		return resp, ok, false
 	}
 
+	// tryGroupResilient retries a single provider on a fresh connection when a
+	// pooled connection dies mid-request (stale socket the server already
+	// closed). Without this, a single-provider pool fails immediately with
+	// "all providers exhausted: ... connection died" because there is no next
+	// provider to fall back to. Bounded so a genuinely-down server still fails
+	// fast. Only transport-level connection death is retried (see
+	// isConnectionDeathError); 430/502/quota and provider removal (!ok) keep
+	// their existing behavior.
+	tryGroupResilient := func(g *providerGroup) (resp Response, ok bool, cancelled bool) {
+		for r := 0; ; r++ {
+			resp, ok, cancelled = tryGroup(g)
+			if cancelled || !ok {
+				return
+			}
+			if r < maxConnDiedRetries && isConnectionDeathError(resp.Err) {
+				continue // dead connection drained; retry fresh on same provider
+			}
+			return
+		}
+	}
+
 	var lastResp Response
 	hasResp := false
 	var lastErr error
@@ -1681,7 +1730,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
 			continue
 		}
-		resp, ok, cancelled := tryGroup(g)
+		resp, ok, cancelled := tryGroupResilient(g)
 		if cancelled {
 			err := ctx.Err()
 			if err == nil {
@@ -1734,7 +1783,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
 			continue
 		}
-		resp, ok, cancelled := tryGroup(g)
+		resp, ok, cancelled := tryGroupResilient(g)
 		if cancelled {
 			err := ctx.Err()
 			if err == nil {


### PR DESCRIPTION
## Problem

Imports (and any caller) intermittently failed with:

```
nntp: all providers exhausted: news.newshosting.com:563+user: nntp: connection died
```

This was **not** a missing article — it was a stale pooled connection. With keepalive disabled by default, an idle connection the server already closed could be handed to a request and fail immediately. In `doSendWithRetry`, a died connection was recorded as `lastErr` and the loop advanced to the **next provider**. With a **single provider** there is no fallback, so the request failed instantly with `all providers exhausted: ... connection died` — even though a fresh connection on the same provider would have succeeded.

## Fix

- **`tryGroupResilient`** wraps `tryGroup` with a bounded same-provider retry (`maxConnDiedRetries = 2`). When a request comes back with a transport-level connection failure, it retries on a fresh connection of the same provider before moving on. The dead connection has already drained by the time the error surfaces, so the retry naturally dials a new one.
- **`isConnectionDeathError`** classifies the two forms connection death can take:
  - `ErrConnectionDied` — an established connection that failed via `failOutstanding` (the user-reported case).
  - Raw IO errors a bootstrap request sees when a freshly-dialed connection dies — `io.EOF`, `io.ErrUnexpectedEOF`, `io.ErrClosedPipe`, `net.ErrClosed`, and any `net.Error` (timeouts/reset/broken pipe).
- Protocol responses (`430`/`502`/quota) and provider removal (`!ok`) keep their existing behavior, so genuine "article not found" still fails fast. Retries are bounded so a genuinely-down server still fails quickly instead of spinning.

Applied to both the main-provider and backup-provider loops.

## Tests

- New `TestClient_SendRetryConnectionDiedSameProvider`: single provider whose first connection dies mid-request, second is healthy; asserts the request recovers (`223`) on a fresh same-provider connection and that ≥2 connections were opened.
- Full suite passes with `-race`.

## Reviewer notes

- Scope intentionally slightly broader than just `ErrConnectionDied`: a freshly-dialed connection dying on its bootstrap request surfaces the raw IO error (e.g. `EOF`), not `ErrConnectionDied`, so both paths are covered by the classifier.
- No public API change. Consumers (e.g. AltMount) benefit automatically after a version bump.