### PR TITLE
perf(pool): parallel STAT probe failover on 430 article-not-found

### DIFF
--- a/nntp.go
+++ b/nntp.go
@@ -1159,13 +1159,24 @@ const (
 type ClientOption func(*clientConfig)
 
 type clientConfig struct {
-	dispatch DispatchStrategy
+	dispatch     DispatchStrategy
+	statProbeOff bool
 }
 
 // WithDispatchStrategy sets the request distribution strategy for main providers.
 // The default is DispatchRoundRobin.
 func WithDispatchStrategy(s DispatchStrategy) ClientOption {
 	return func(cfg *clientConfig) { cfg.dispatch = s }
+}
+
+// WithStatProbe enables or disables parallel STAT probing on 430 failover.
+// When enabled (the default), after the first 430 response the remaining
+// providers are probed concurrently with lightweight STAT commands; only the
+// first provider that confirms article existence (223) receives the full
+// request. This reduces "article missing on N providers" latency from
+// sum-of-RTTs to max-of-RTTs.
+func WithStatProbe(enabled bool) ClientOption {
+	return func(cfg *clientConfig) { cfg.statProbeOff = !enabled }
 }
 
 // Provider describes a single NNTP server with its own credentials and connection count.
@@ -1273,7 +1284,8 @@ type Client struct {
 	backupGroups atomic.Pointer[[]*providerGroup]
 	nextIdx      atomic.Uint64 // round-robin counter for mainGroups
 
-	dispatch DispatchStrategy // set once by NewClient, read-only after
+	dispatch   DispatchStrategy // set once by NewClient, read-only after
+	statProbe  bool             // set once by NewClient; enables parallel STAT probing on 430
 
 	providerIdx atomic.Int64 // monotonic counter for unnamed providers
 
@@ -1505,6 +1517,7 @@ func NewClient(ctx context.Context, providers []Provider, opts ...ClientOption) 
 		ctx:       ctx,
 		cancel:    cancel,
 		dispatch:  cfg.dispatch,
+		statProbe: !cfg.statProbeOff,
 		startTime: time.Now(),
 	}
 	// Initialize empty slices.
@@ -1573,6 +1586,259 @@ func (c *Client) SendPriority(ctx context.Context, payload []byte, bodyWriter io
 	return respCh
 }
 
+// extractProbeMsgID returns the "<id@host>" message-ID from a BODY, HEAD, or
+// ARTICLE payload, or nil when the payload has no message-ID (GROUP, DATE, …)
+// or when the command is already STAT or POST (probing would be redundant or
+// inapplicable).
+func extractProbeMsgID(payload []byte) []byte {
+	if len(payload) == 0 {
+		return nil
+	}
+	// Reject commands where probing is irrelevant or already done.
+	switch {
+	case len(payload) >= 4 && (payload[0]|0x20) == 's' && (payload[1]|0x20) == 't' &&
+		(payload[2]|0x20) == 'a' && (payload[3]|0x20) == 't':
+		return nil // STAT
+	case len(payload) >= 4 && (payload[0]|0x20) == 'p' && (payload[1]|0x20) == 'o' &&
+		(payload[2]|0x20) == 's' && (payload[3]|0x20) == 't':
+		return nil // POST
+	}
+	open := bytes.IndexByte(payload, '<')
+	if open < 0 {
+		return nil
+	}
+	close := bytes.IndexByte(payload[open:], '>')
+	if close < 0 {
+		return nil
+	}
+	return payload[open : open+close+1]
+}
+
+// probeResult carries the outcome of one parallel STAT probe.
+type probeResult struct {
+	g         *providerGroup
+	resp      Response
+	ok        bool
+	cancelled bool
+}
+
+// raceCandidates probes candidates in parallel with STAT on the priority lane,
+// then sends the real payload to the first provider that confirms 223.
+// All-miss latency is max-of-RTTs instead of sum-of-RTTs.
+//
+// Note: when all probes miss, respCh is NOT written; the caller must deliver
+// the saved 430 response from the first provider that triggered the race.
+func (c *Client) raceCandidates(
+	ctx context.Context,
+	candidates []*providerGroup,
+	statPayload, payload []byte,
+	bodyWriter io.Writer,
+	onMeta func(YEncMeta),
+	skipHosts *[4]string,
+	skipCount *int,
+	respCh chan<- Response,
+) (delivered, cancelled bool, lastErr error) {
+	// Filter to live candidates (skip same hosts and quota-exceeded).
+	live := make([]*providerGroup, 0, len(candidates))
+	seen := make(map[string]bool)
+	for _, g := range candidates {
+		if hostSkipped(g.host, skipHosts, *skipCount) {
+			continue
+		}
+		if g.isQuotaExceeded() {
+			lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
+			continue
+		}
+		if g.host != "" && seen[g.host] {
+			continue
+		}
+		if g.host != "" {
+			seen[g.host] = true
+		}
+		live = append(live, g)
+	}
+
+	if len(live) == 0 {
+		return false, false, lastErr
+	}
+
+	// Single live candidate: skip the probe RTT and send the real payload directly.
+	if len(live) == 1 {
+		g := live[0]
+		resp, ok, done := c.tryGroup(ctx, g, payload, bodyWriter, onMeta, true)
+		if done {
+			return false, true, lastErr
+		}
+		if !ok {
+			return false, false, lastErr
+		}
+		if resp.Err != nil {
+			return false, false, resp.Err
+		}
+		if resp.StatusCode == 502 {
+			_ = c.RemoveProvider(g.name)
+			if g.p.ReconnectDelay > 0 {
+				c.scheduleReconnect(g)
+			}
+			return false, false, fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
+		}
+		if resp.StatusCode == 430 || resp.StatusCode == 423 {
+			if g.host != "" && *skipCount < len(skipHosts) {
+				skipHosts[*skipCount] = g.host
+				*skipCount++
+			}
+			c.nextIdx.Add(1)
+			return false, false, lastErr
+		}
+		respCh <- resp
+		return true, false, lastErr
+	}
+
+	// ≥2 candidates: probe all in parallel.
+	results := make(chan probeResult, len(live))
+	for _, g := range live {
+		go func(g *providerGroup) {
+			resp, ok, done := c.tryGroup(ctx, g, statPayload, nil, nil, true)
+			results <- probeResult{g: g, resp: resp, ok: ok, cancelled: done}
+		}(g)
+	}
+
+	// Collect ALL probe results before acting on the winner, so that side
+	// effects like 502 provider removal are applied regardless of order.
+	var winner *providerGroup
+	for range live {
+		pr := <-results
+		if pr.cancelled {
+			cancelled = true
+			continue
+		}
+		if !pr.ok {
+			continue
+		}
+		if pr.resp.Err != nil {
+			lastErr = pr.resp.Err
+			continue
+		}
+		g := pr.g
+		switch pr.resp.StatusCode {
+		case 502:
+			_ = c.RemoveProvider(g.name)
+			if g.p.ReconnectDelay > 0 {
+				c.scheduleReconnect(g)
+			}
+			lastErr = fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
+		case 430, 423:
+			if g.host != "" && *skipCount < len(skipHosts) {
+				skipHosts[*skipCount] = g.host
+				*skipCount++
+			}
+			c.nextIdx.Add(1)
+		case 223:
+			if winner == nil {
+				winner = g // first 223; keep collecting for 502s
+			}
+		default:
+			lastErr = fmt.Errorf("%s: unexpected STAT probe status %d", g.name, pr.resp.StatusCode)
+		}
+	}
+
+	if cancelled {
+		return false, true, lastErr
+	}
+
+	if winner == nil {
+		return false, false, lastErr
+	}
+
+	// Send the real payload to the winner on the priority lane.
+	resp, ok, done := c.tryGroup(ctx, winner, payload, bodyWriter, onMeta, true)
+	if done {
+		return false, true, lastErr
+	}
+	if !ok {
+		return false, false, lastErr
+	}
+	if resp.Err != nil {
+		return false, false, resp.Err
+	}
+	if resp.StatusCode == 430 || resp.StatusCode == 423 {
+		// Rare: article expired between STAT and BODY.
+		if winner.host != "" && *skipCount < len(skipHosts) {
+			skipHosts[*skipCount] = winner.host
+			*skipCount++
+		}
+		c.nextIdx.Add(1)
+		return false, false, lastErr
+	}
+	if resp.StatusCode == 502 {
+		_ = c.RemoveProvider(winner.name)
+		if winner.p.ReconnectDelay > 0 {
+			c.scheduleReconnect(winner)
+		}
+		return false, false, fmt.Errorf("%s: %w", winner.name, ErrServiceUnavailable)
+	}
+	respCh <- resp
+	return true, false, lastErr
+}
+
+// tryGroup dispatches a single request to a provider group and waits for the
+// response. priority=true routes through the priority channels.
+func (c *Client) tryGroup(
+	ctx context.Context,
+	g *providerGroup,
+	payload []byte,
+	bodyWriter io.Writer,
+	onMeta func(YEncMeta),
+	priority bool,
+) (resp Response, ok bool, done bool) {
+	attemptCtx, attemptCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer attemptCancel()
+
+	innerCh := make(chan Response, 1)
+	req := &Request{
+		Ctx:        attemptCtx,
+		Payload:    payload,
+		RespCh:     innerCh,
+		BodyWriter: bodyWriter,
+		OnMeta:     onMeta,
+	}
+
+	var hotCh chan *Request
+	var coldCh chan *Request
+	if priority {
+		hotCh = g.hotPrioCh
+		coldCh = g.prioCh
+	} else {
+		hotCh = g.hotReqCh
+		coldCh = g.reqCh
+	}
+
+	select {
+	case hotCh <- req:
+	default:
+		select {
+		case <-c.ctx.Done():
+			return Response{}, false, true
+		case <-attemptCtx.Done():
+			return Response{}, false, ctx.Err() != nil
+		case <-g.ctx.Done():
+			return Response{}, false, false
+		case coldCh <- req:
+		}
+	}
+
+	select {
+	case resp, ok = <-innerCh:
+	case <-c.ctx.Done():
+		return Response{}, false, true
+	case <-attemptCtx.Done():
+		return Response{}, false, ctx.Err() != nil
+	case <-g.ctx.Done():
+		return Response{}, false, false
+	}
+	return resp, ok, false
+}
+
 // hostSkipped reports whether host is already in the skip list.
 // Empty hosts (Factory-based providers) are never skipped.
 func hostSkipped(host string, skipHosts *[4]string, count int) bool {
@@ -1591,85 +1857,49 @@ func (c *Client) sendWithRetry(ctx context.Context, payload []byte, bodyWriter i
 	c.doSendWithRetry(ctx, payload, bodyWriter, onMeta, respCh, false)
 }
 
+// tryGroupResilient retries a single provider on a fresh connection when a
+// pooled connection dies mid-request (stale socket the server already
+// closed). Without this, a single-provider pool fails immediately with
+// "all providers exhausted: ... connection died" because there is no next
+// provider to fall back to. Bounded so a genuinely-down server still fails
+// fast. Only transport-level connection death is retried (see
+// isConnectionDeathError); 430/502/quota and provider removal (!ok) keep
+// their existing behavior.
+func (c *Client) tryGroupResilient(
+	ctx context.Context,
+	g *providerGroup,
+	payload []byte,
+	bodyWriter io.Writer,
+	onMeta func(YEncMeta),
+	priority bool,
+) (resp Response, ok bool, cancelled bool) {
+	for r := 0; ; r++ {
+		resp, ok, cancelled = c.tryGroup(ctx, g, payload, bodyWriter, onMeta, priority)
+		if cancelled || !ok {
+			return
+		}
+		if r < maxConnDiedRetries && isConnectionDeathError(resp.Err) {
+			continue // dead connection drained; retry fresh on same provider
+		}
+		return
+	}
+}
+
 func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter io.Writer, onMeta func(YEncMeta), respCh chan Response, priority bool) {
 	defer close(respCh)
 
-	tryGroup := func(g *providerGroup) (resp Response, ok bool, done bool) {
-		attemptCtx, attemptCancel := context.WithTimeout(ctx, 2*time.Second)
-		defer attemptCancel()
-
-		innerCh := make(chan Response, 1)
-		req := &Request{
-			Ctx:        attemptCtx,
-			Payload:    payload,
-			RespCh:     innerCh,
-			BodyWriter: bodyWriter,
-			OnMeta:     onMeta,
-		}
-
-		var hotCh chan *Request
-		var coldCh chan *Request
-		if priority {
-			hotCh = g.hotPrioCh
-			coldCh = g.prioCh
-		} else {
-			hotCh = g.hotReqCh
-			coldCh = g.reqCh
-		}
-
-		// Try hot channel first (non-blocking): succeeds only if a
-		// hot connection is already waiting with inflight capacity.
-		select {
-		case hotCh <- req:
-		default:
-			// No hot connection available — send to cold channel.
-			select {
-			case <-c.ctx.Done():
-				return Response{}, false, true
-			case <-attemptCtx.Done():
-				return Response{}, false, ctx.Err() != nil
-			case <-g.ctx.Done():
-				return Response{}, false, false
-			case coldCh <- req:
-			}
-		}
-
-		select {
-		case resp, ok = <-innerCh:
-		case <-c.ctx.Done():
-			return Response{}, false, true
-		case <-attemptCtx.Done():
-			return Response{}, false, ctx.Err() != nil
-		case <-g.ctx.Done():
-			return Response{}, false, false // provider removed; try others
-		}
-		return resp, ok, false
-	}
-
-	// tryGroupResilient retries a single provider on a fresh connection when a
-	// pooled connection dies mid-request (stale socket the server already
-	// closed). Without this, a single-provider pool fails immediately with
-	// "all providers exhausted: ... connection died" because there is no next
-	// provider to fall back to. Bounded so a genuinely-down server still fails
-	// fast. Only transport-level connection death is retried (see
-	// isConnectionDeathError); 430/502/quota and provider removal (!ok) keep
-	// their existing behavior.
-	tryGroupResilient := func(g *providerGroup) (resp Response, ok bool, cancelled bool) {
-		for r := 0; ; r++ {
-			resp, ok, cancelled = tryGroup(g)
-			if cancelled || !ok {
-				return
-			}
-			if r < maxConnDiedRetries && isConnectionDeathError(resp.Err) {
-				continue // dead connection drained; retry fresh on same provider
-			}
-			return
-		}
+	// Precompute for STAT probe: extract message-ID once.
+	msgID := extractProbeMsgID(payload)
+	raceable := c.statProbe && msgID != nil
+	var statPayload []byte
+	if raceable {
+		statPayload = append(append([]byte("STAT "), msgID...), "\r\n"...)
 	}
 
 	var lastResp Response
 	hasResp := false
 	var lastErr error
+	post430 := false
 
 	// Track hosts that returned 430 so we can skip other providers on
 	// the same server (different credentials won't help).
@@ -1730,7 +1960,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
 			continue
 		}
-		resp, ok, cancelled := tryGroupResilient(g)
+		resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430)
 		if cancelled {
 			err := ctx.Err()
 			if err == nil {
@@ -1765,6 +1995,34 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			}
 			lastResp = resp
 			hasResp = true
+			post430 = true
+
+			if raceable {
+				// Build remaining mains and race them in parallel via STAT.
+				rest := make([]*providerGroup, 0, n-attempt-1)
+				for a := attempt + 1; a < n; a++ {
+					rest = append(rest, mains[(start+a)%n])
+				}
+				delivered, cancelled, raceErr := c.raceCandidates(
+					ctx, rest, statPayload, payload, bodyWriter, onMeta,
+					&skipHosts, &skipCount, respCh,
+				)
+				if cancelled {
+					err := ctx.Err()
+					if err == nil {
+						err = c.ctx.Err()
+					}
+					respCh <- Response{Err: err}
+					return
+				}
+				if delivered {
+					return
+				}
+				if raceErr != nil {
+					lastErr = raceErr
+				}
+				break // all remaining mains were probed in the race
+			}
 			continue
 		}
 		// Success.
@@ -1772,18 +2030,13 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 		return
 	}
 
-	// 2. All main providers returned 430 (or died) — try backup providers in order.
+	// 2. All main providers returned 430 (or died) — try backup providers.
 	backups := *c.backupGroups.Load()
-	for i := range backups {
-		g := backups[i]
-		if hostSkipped(g.host, &skipHosts, skipCount) {
-			continue
-		}
-		if g.isQuotaExceeded() {
-			lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
-			continue
-		}
-		resp, ok, cancelled := tryGroupResilient(g)
+	if raceable && post430 {
+		delivered, cancelled, raceErr := c.raceCandidates(
+			ctx, backups, statPayload, payload, bodyWriter, onMeta,
+			&skipHosts, &skipCount, respCh,
+		)
 		if cancelled {
 			err := ctx.Err()
 			if err == nil {
@@ -1792,24 +2045,50 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			respCh <- Response{Err: err}
 			return
 		}
-		if !ok {
-			continue
+		if delivered {
+			return
 		}
-		if resp.Err != nil {
-			lastErr = resp.Err
-			continue
+		if raceErr != nil {
+			lastErr = raceErr
 		}
-		if resp.StatusCode == 502 {
-			_ = c.RemoveProvider(g.name)
-			if g.p.ReconnectDelay > 0 {
-				c.scheduleReconnect(g)
+	} else {
+		for i := range backups {
+			g := backups[i]
+			if hostSkipped(g.host, &skipHosts, skipCount) {
+				continue
 			}
-			lastErr = fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
-			continue
+			if g.isQuotaExceeded() {
+				lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
+				continue
+			}
+			resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430)
+			if cancelled {
+				err := ctx.Err()
+				if err == nil {
+					err = c.ctx.Err()
+				}
+				respCh <- Response{Err: err}
+				return
+			}
+			if !ok {
+				continue
+			}
+			if resp.Err != nil {
+				lastErr = resp.Err
+				continue
+			}
+			if resp.StatusCode == 502 {
+				_ = c.RemoveProvider(g.name)
+				if g.p.ReconnectDelay > 0 {
+					c.scheduleReconnect(g)
+				}
+				lastErr = fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
+				continue
+			}
+			// Deliver whatever backup returns (including 430).
+			respCh <- resp
+			return
 		}
-		// Deliver whatever backup returns (including 430).
-		respCh <- resp
-		return
 	}
 
 	// 3. All providers exhausted — deliver the last 430, the last error, or a fallback.

--- a/nntp_test.go
+++ b/nntp_test.go
@@ -1095,6 +1095,459 @@ func TestFailRequest_DoubleClose(t *testing.T) {
 	failRequest(ch, fmt.Errorf("err2"))
 }
 
+// --- extractProbeMsgID ---
+
+func TestExtractProbeMsgID(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string // empty means nil expected
+	}{
+		{"BODY with msgid", "BODY <a@b>\r\n", "<a@b>"},
+		{"HEAD with msgid", "HEAD <foo@bar.example>\r\n", "<foo@bar.example>"},
+		{"ARTICLE with msgid", "ARTICLE <x@y>\r\n", "<x@y>"},
+		{"STAT is excluded", "STAT <a@b>\r\n", ""},
+		{"POST is excluded", "POST\r\n", ""},
+		{"GROUP has no msgid", "GROUP alt.test\r\n", ""},
+		{"DATE has no msgid", "DATE\r\n", ""},
+		{"malformed no closing >", "BODY <a@b\r\n", ""},
+		{"empty payload", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractProbeMsgID([]byte(tt.payload))
+			if tt.want == "" {
+				if got != nil {
+					t.Errorf("extractProbeMsgID() = %q, want nil", got)
+				}
+			} else {
+				if string(got) != tt.want {
+					t.Errorf("extractProbeMsgID() = %q, want %q", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// --- STAT probe failover tests ---
+
+// makeStatProbeFactory creates a ConnFactory for STAT probe tests.
+// cmdLog (guarded by mu) records every non-DATE command received.
+// responses maps command prefixes to response lines.
+func makeStatProbeFactory(t *testing.T, mu *sync.Mutex, cmdLog *[]string, responses map[string]string) ConnFactory {
+	t.Helper()
+	return func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 server ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				cmd := strings.TrimRight(string(buf[:n]), "\r\n")
+				// Always respond to DATE for ping.
+				if strings.HasPrefix(cmd, "DATE") {
+					_, _ = server.Write([]byte("111 20240315120000\r\n"))
+					continue
+				}
+				mu.Lock()
+				*cmdLog = append(*cmdLog, cmd)
+				mu.Unlock()
+				var reply string
+				for prefix, resp := range responses {
+					if strings.HasPrefix(cmd, prefix) {
+						reply = resp
+						break
+					}
+				}
+				if reply == "" {
+					reply = "500 unknown command"
+				}
+				_, _ = fmt.Fprintf(server, "%s\r\n", reply)
+			}
+		}()
+		return client, nil
+	}
+}
+
+func TestSend_430StatProbeWinnerGetsBody(t *testing.T) {
+	// P1: BODY→430 (first attempt, forces probe).
+	// P2: STAT→430.
+	// P3: STAT→223, BODY→222 (winner).
+	var mu sync.Mutex
+	var p1Cmds, p2Cmds, p3Cmds []string
+
+	c, err := NewClient(context.Background(), []Provider{
+		{
+			Factory: makeStatProbeFactory(t, &mu, &p1Cmds, map[string]string{
+				"BODY": "430 no such article",
+				"STAT": "430 no such article",
+			}),
+			Connections: 1,
+		},
+		{
+			Factory: makeStatProbeFactory(t, &mu, &p2Cmds, map[string]string{
+				"STAT": "430 no such article",
+			}),
+			Connections: 1,
+		},
+		{
+			Factory: makeStatProbeFactory(t, &mu, &p3Cmds, map[string]string{
+				"STAT": "223 0 <test@host> article exists",
+				"BODY": "222 0 <test@host> body follows\r\n.\r\n",
+			}),
+			Connections: 1,
+		},
+	}, WithDispatchStrategy(DispatchFIFO))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := <-c.Send(ctx, []byte("BODY <test@host>\r\n"), nil)
+	if resp.Err != nil {
+		t.Fatalf("unexpected error: %v", resp.Err)
+	}
+	if resp.StatusCode != 222 {
+		t.Errorf("StatusCode = %d, want 222", resp.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// P1 should have received BODY.
+	if len(p1Cmds) == 0 || !strings.HasPrefix(p1Cmds[0], "BODY") {
+		t.Errorf("P1 commands = %v, want first to be BODY", p1Cmds)
+	}
+	// P2 should have received STAT (probe), not BODY.
+	if len(p2Cmds) == 0 || !strings.HasPrefix(p2Cmds[0], "STAT") {
+		t.Errorf("P2 commands = %v, want first to be STAT probe", p2Cmds)
+	}
+	for _, cmd := range p2Cmds {
+		if strings.HasPrefix(cmd, "BODY") {
+			t.Error("P2 should not have received BODY")
+		}
+	}
+	// P3 should have received STAT then BODY.
+	if len(p3Cmds) < 2 {
+		t.Fatalf("P3 commands = %v, want at least STAT + BODY", p3Cmds)
+	}
+	if !strings.HasPrefix(p3Cmds[0], "STAT") {
+		t.Errorf("P3 first command = %q, want STAT", p3Cmds[0])
+	}
+	if !strings.HasPrefix(p3Cmds[1], "BODY") {
+		t.Errorf("P3 second command = %q, want BODY", p3Cmds[1])
+	}
+}
+
+func TestSend_430StatProbeParallel(t *testing.T) {
+	// P1: BODY→430 immediately.
+	// P2 and P3: STAT responds after 150ms with 430.
+	// If probed in parallel, total wait ≈ 150ms; sequential would be ≈ 300ms.
+	delay := 150 * time.Millisecond
+
+	makeDelayedFactory := func(cmdLog *[]string, mu *sync.Mutex, statReply string) ConnFactory {
+		return func(ctx context.Context) (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				defer func() { _ = server.Close() }()
+				_, _ = server.Write([]byte("200 server ready\r\n"))
+				buf := make([]byte, 4096)
+				for {
+					n, err := server.Read(buf)
+					if err != nil {
+						return
+					}
+					cmd := strings.TrimRight(string(buf[:n]), "\r\n")
+					if strings.HasPrefix(cmd, "DATE") {
+						_, _ = server.Write([]byte("111 20240315120000\r\n"))
+						continue
+					}
+					mu.Lock()
+					*cmdLog = append(*cmdLog, cmd)
+					mu.Unlock()
+					if strings.HasPrefix(cmd, "STAT") {
+						time.Sleep(delay)
+					}
+					_, _ = fmt.Fprintf(server, "%s\r\n", statReply)
+				}
+			}()
+			return client, nil
+		}
+	}
+
+	var mu sync.Mutex
+	var p1Cmds, p2Cmds, p3Cmds []string
+
+	c, err := NewClient(context.Background(), []Provider{
+		{
+			Factory: makeStatProbeFactory(t, &mu, &p1Cmds, map[string]string{
+				"BODY": "430 no such article",
+				"STAT": "430 no such article",
+			}),
+			Connections: 1,
+		},
+		{Factory: makeDelayedFactory(&p2Cmds, &mu, "430 no such article"), Connections: 1},
+		{Factory: makeDelayedFactory(&p3Cmds, &mu, "430 no such article"), Connections: 1},
+	}, WithDispatchStrategy(DispatchFIFO))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	resp := <-c.Send(ctx, []byte("BODY <test@host>\r\n"), nil)
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != 430 {
+		t.Errorf("StatusCode = %d, want 430", resp.StatusCode)
+	}
+	// Parallel: should finish in ~delay, not ~2*delay.
+	// Allow generous margin (3x) to avoid flakiness.
+	if elapsed > 3*delay {
+		t.Errorf("elapsed = %v, want ≤ %v (probes should be parallel)", elapsed, 3*delay)
+	}
+}
+
+func TestSend_All430WithStatProbeReturnsSaved430(t *testing.T) {
+	makeAll430 := func() ConnFactory {
+		return func(ctx context.Context) (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				defer func() { _ = server.Close() }()
+				_, _ = server.Write([]byte("200 server ready\r\n"))
+				buf := make([]byte, 4096)
+				for {
+					n, err := server.Read(buf)
+					if err != nil {
+						return
+					}
+					cmd := string(buf[:n])
+					if strings.HasPrefix(cmd, "DATE") {
+						_, _ = server.Write([]byte("111 20240315120000\r\n"))
+					} else {
+						_, _ = server.Write([]byte("430 no such article\r\n"))
+					}
+				}
+			}()
+			return client, nil
+		}
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: makeAll430(), Connections: 1},
+		{Factory: makeAll430(), Connections: 1},
+		{Factory: makeAll430(), Connections: 1, Backup: true},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := <-c.Send(ctx, []byte("BODY <test@host>\r\n"), nil)
+	if resp.Err != nil {
+		t.Fatalf("unexpected error: %v", resp.Err)
+	}
+	if resp.StatusCode != 430 {
+		t.Errorf("StatusCode = %d, want 430", resp.StatusCode)
+	}
+}
+
+func TestSend_430NoMsgIDUsesSequentialFallback(t *testing.T) {
+	// GROUP command has no message-ID: probe should not be used.
+	// P1 returns error; P2 returns 211 success.
+	var mu sync.Mutex
+	var p2Cmds []string
+
+	makeGroupFactory := func(reply string, cmdLog *[]string) ConnFactory {
+		return func(ctx context.Context) (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				defer func() { _ = server.Close() }()
+				_, _ = server.Write([]byte("200 server ready\r\n"))
+				buf := make([]byte, 4096)
+				for {
+					n, err := server.Read(buf)
+					if err != nil {
+						return
+					}
+					cmd := strings.TrimRight(string(buf[:n]), "\r\n")
+					if strings.HasPrefix(cmd, "DATE") {
+						_, _ = server.Write([]byte("111 20240315120000\r\n"))
+						continue
+					}
+					if cmdLog != nil {
+						mu.Lock()
+						*cmdLog = append(*cmdLog, cmd)
+						mu.Unlock()
+					}
+					_, _ = fmt.Fprintf(server, "%s\r\n", reply)
+				}
+			}()
+			return client, nil
+		}
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: makeGroupFactory("430 no such article", nil), Connections: 1},
+		{Factory: makeGroupFactory("211 15 1 15 alt.test", &p2Cmds), Connections: 1},
+	}, WithDispatchStrategy(DispatchFIFO))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Use a command without a message-ID: STAT with a bare article number.
+	resp := <-c.Send(ctx, []byte("GROUP alt.test\r\n"), nil)
+	if resp.StatusCode != 211 {
+		t.Errorf("StatusCode = %d, want 211", resp.StatusCode)
+	}
+
+	// P2 should not have received any STAT probe — only the GROUP command.
+	mu.Lock()
+	defer mu.Unlock()
+	for _, cmd := range p2Cmds {
+		if strings.HasPrefix(cmd, "STAT") {
+			t.Errorf("P2 received STAT probe %q, expected only GROUP fallback", cmd)
+		}
+	}
+}
+
+func TestSend_WithStatProbeDisabled(t *testing.T) {
+	// With WithStatProbe(false), should NOT probe — fall back sequentially.
+	var mu sync.Mutex
+	var p1Cmds, p2Cmds []string
+
+	c, err := NewClient(context.Background(), []Provider{
+		{
+			Factory: makeStatProbeFactory(t, &mu, &p1Cmds, map[string]string{
+				"BODY": "430 no such article",
+			}),
+			Connections: 1,
+		},
+		{
+			Factory: makeStatProbeFactory(t, &mu, &p2Cmds, map[string]string{
+				"BODY": "222 0 <test@host> body\r\n.\r\n",
+			}),
+			Connections: 1,
+		},
+	}, WithDispatchStrategy(DispatchFIFO), WithStatProbe(false))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := <-c.Send(ctx, []byte("BODY <test@host>\r\n"), nil)
+	if resp.StatusCode != 222 {
+		t.Errorf("StatusCode = %d, want 222", resp.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// No STAT commands should have been sent to either provider.
+	for _, cmd := range p1Cmds {
+		if strings.HasPrefix(cmd, "STAT") {
+			t.Errorf("P1 received STAT %q but StatProbe is disabled", cmd)
+		}
+	}
+	for _, cmd := range p2Cmds {
+		if strings.HasPrefix(cmd, "STAT") {
+			t.Errorf("P2 received STAT %q but StatProbe is disabled", cmd)
+		}
+	}
+}
+
+func TestSend_430Probe502RemovesProvider(t *testing.T) {
+	// P1: BODY→430 (triggers probe of remaining providers).
+	// P2: STAT→502 (probe returns 502; P2 should be removed from pool).
+	// P3: STAT→223, BODY→222 (winner).
+	var mu sync.Mutex
+	var p1Cmds, p2Cmds, p3Cmds []string
+
+	p2Factory := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 server ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				cmd := strings.TrimRight(string(buf[:n]), "\r\n")
+				if strings.HasPrefix(cmd, "DATE") {
+					_, _ = server.Write([]byte("111 20240315120000\r\n"))
+					continue
+				}
+				mu.Lock()
+				p2Cmds = append(p2Cmds, cmd)
+				mu.Unlock()
+				// Always reply 502 on STAT probe.
+				_, _ = server.Write([]byte("502 service unavailable\r\n"))
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{
+			Factory: makeStatProbeFactory(t, &mu, &p1Cmds, map[string]string{
+				"BODY": "430 no such article",
+				"STAT": "430 no such article",
+			}),
+			Connections: 1,
+		},
+		{Factory: p2Factory, Connections: 1},
+		{
+			Factory: makeStatProbeFactory(t, &mu, &p3Cmds, map[string]string{
+				"STAT": "223 0 <test@host> exists",
+				"BODY": "222 0 <test@host> body\r\n.\r\n",
+			}),
+			Connections: 1,
+		},
+	}, WithDispatchStrategy(DispatchFIFO))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp := <-c.Send(ctx, []byte("BODY <test@host>\r\n"), nil)
+	if resp.Err != nil {
+		t.Fatalf("unexpected error: %v", resp.Err)
+	}
+	if resp.StatusCode != 222 {
+		t.Errorf("StatusCode = %d, want 222", resp.StatusCode)
+	}
+
+	// P2 should have been removed due to 502 probe response.
+	if c.NumProviders() != 2 {
+		t.Errorf("NumProviders() = %d, want 2 (P2 removed after 502 probe response)", c.NumProviders())
+	}
+}
+
 // --- resolveProviderName ---
 
 func TestResolveProviderName(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Problem**: When an article is missing, the pool walked providers sequentially — each 430 added a full RTT (up to 2s per attempt), so "missing everywhere" latency was sum-of-RTTs across all providers.
- **Solution**: After the first 430, probe remaining providers concurrently with cheap `STAT <msgid>` commands on the priority lane, then send the real request (BODY/HEAD) only to the first provider that confirms the article exists (223). All-miss latency drops from sum-of-RTTs to max-of-RTTs.
- **Opt-out**: `WithStatProbe(false)` restores the previous sequential behaviour.

## Changes

### `nntp.go`
- `WithStatProbe(bool) ClientOption` — new option, default **enabled**
- `extractProbeMsgID(payload []byte) []byte` — extracts `<id@host>` from BODY/HEAD/ARTICLE payloads; returns nil for STAT/POST/GROUP (falls back to sequential for those)
- `tryGroup` / `tryGroupResilient` promoted from `doSendWithRetry` closures to `Client` methods parameterized by payload, bodyWriter, onMeta, and priority — enables probes to use a different payload and force the priority lane
- `raceCandidates(...)` — probes all remaining candidates in parallel; collects **all** probe results before acting on the winner (so 502 provider removals apply regardless of probe arrival order); sends real payload to the first 223 responder via priority lane
- `doSendWithRetry` rewired: on first 430, builds remainder slice and calls `raceCandidates`; backups also go through `raceCandidates` when raceable; post-430 sequential fallbacks (non-msgid payloads) use the priority lane

### `nntp_test.go`
8 new tests:
1. `TestExtractProbeMsgID` — table-driven unit test for the extraction helper
2. `TestSend_430StatProbeWinnerGetsBody` — P2 receives STAT probe (not BODY); P3 receives STAT then BODY; result 222
3. `TestSend_430StatProbeParallel` — two 150ms-delayed probes resolve in ~150ms total (not ~300ms)
4. `TestSend_All430WithStatProbeReturnsSaved430` — all providers 430; saved first-provider 430 is returned
5. `TestSend_430NoMsgIDUsesSequentialFallback` — GROUP payload triggers no STAT probes
6. `TestSend_WithStatProbeDisabled` — no STAT commands with `WithStatProbe(false)`
7. `TestSend_430Probe502RemovesProvider` — 502 on STAT probe removes provider; P3 wins
8. `TestSend_430StatProbeParallel` — parallelism timing assertion

## Test plan

- [ ] `make check` passes: 0 lint issues, all tests green with `-race`
- [ ] `TestSend_430StatProbeParallel` confirms probes are parallel (≤3× single-probe delay)
- [ ] `TestSend_WithStatProbeDisabled` confirms opt-out works
- [ ] Existing tests (`TestSend_All430Propagates`, `TestAddThenSend`, etc.) unchanged