### PR TITLE
perf(pool): stabilize download speed with stall-aware timeouts and speed-weighted dispatch

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,8 +1,16 @@
 package nntppool
 
 import (
+	"math"
 	"sync/atomic"
 	"time"
+)
+
+// ewmaAlphaNum/ewmaAlphaDen express the EWMA smoothing factor (α = 0.2) as a
+// rational so the integer update can avoid floating point: new = old + α(sample-old).
+const (
+	ewmaAlphaNum = 1
+	ewmaAlphaDen = 5
 )
 
 // PingResult holds the outcome of a DATE-based ping to a provider.
@@ -20,21 +28,90 @@ type providerStats struct {
 	Errors        atomic.Int64 // network errors, bad status codes
 	Ping          PingResult   // result of initial DATE ping
 
+	// ttfbEWMA is the exponentially weighted moving average of observed
+	// time-to-first-byte, in nanoseconds. 0 = no sample yet. Seeded from the
+	// startup ping RTT. Drives the adaptive per-attempt timeout.
+	ttfbEWMA atomic.Int64
+
+	// speedEWMA is the EWMA of observed body throughput in bytes/sec, stored as
+	// math.Float64bits. 0 = no sample yet. Drives speed-aware dispatch weights.
+	speedEWMA atomic.Uint64
+
 	// Quota tracking. quotaBytes is set once at group init (0 = unlimited).
 	quotaBytes    int64
 	quotaUsed     atomic.Int64 // bytes consumed in the current quota period
 	quotaExceeded atomic.Bool  // cached flag: set when quotaUsed >= quotaBytes; cleared on period reset
 }
 
+// recordTTFB updates the provider's time-to-first-byte EWMA. sample is the
+// measured payload-write → first-response-byte duration; non-positive samples
+// (and absent stats) are ignored as "not measured".
+func recordTTFB(stats *providerStats, sample time.Duration) {
+	if stats == nil || sample <= 0 {
+		return
+	}
+	s := int64(sample)
+	for {
+		old := stats.ttfbEWMA.Load()
+		var next int64
+		if old == 0 {
+			next = s
+		} else {
+			// Rounded float update so a small delta isn't truncated to zero
+			// (which would freeze the EWMA on very low-latency links).
+			next = old + int64(math.Round(float64(s-old)*ewmaAlphaNum/ewmaAlphaDen))
+		}
+		if stats.ttfbEWMA.CompareAndSwap(old, next) {
+			return
+		}
+	}
+}
+
+// recordSpeed updates the provider's throughput EWMA (bytes/sec) from a
+// completed body transfer. Samples below speedSampleFloor bytes are ignored as
+// noise (STAT/HEAD/430 responses).
+func recordSpeed(stats *providerStats, bytes int64, elapsed time.Duration) {
+	if stats == nil || bytes < speedSampleFloor || elapsed <= 0 {
+		return
+	}
+	sample := float64(bytes) / elapsed.Seconds()
+	for {
+		oldBits := stats.speedEWMA.Load()
+		old := math.Float64frombits(oldBits)
+		var next float64
+		if old == 0 {
+			next = sample
+		} else {
+			next = old + (sample-old)*ewmaAlphaNum/ewmaAlphaDen
+		}
+		if stats.speedEWMA.CompareAndSwap(oldBits, math.Float64bits(next)) {
+			return
+		}
+	}
+}
+
+// speedSampleFloor is the minimum body size (bytes) for a throughput sample to
+// count, filtering out tiny control responses.
+const speedSampleFloor = 16 * 1024
+
+// speedEWMABytesPerSec returns the current throughput EWMA in bytes/sec, or 0
+// when no sample has been recorded yet.
+func speedEWMABytesPerSec(stats *providerStats) float64 {
+	return math.Float64frombits(stats.speedEWMA.Load())
+}
+
 // ProviderStats is a public snapshot of one provider's metrics.
 type ProviderStats struct {
 	Name              string
 	AvgSpeed          float64 // bytes/sec average since client start
+	SpeedEWMA         float64 // bytes/sec recent throughput estimate (drives speed-aware dispatch); 0 = no sample
 	BytesConsumed     int64   // raw wire bytes consumed since client start
 	Missing           int64
 	Errors            int64
-	ActiveConnections int // currently running connections
-	MaxConnections    int // configured connection slots
+	ActiveConnections int           // currently running connections
+	MaxConnections    int           // configured connection slots
+	AvailableSlots    int           // connection slots currently free (allowed - held)
+	TTFB              time.Duration // recent time-to-first-byte estimate (seeded from ping RTT); 0 = no sample
 	Ping              PingResult
 
 	// Quota fields. QuotaBytes is 0 when no quota is configured.

--- a/nntp.go
+++ b/nntp.go
@@ -70,6 +70,37 @@ const (
 	// The dead connection has drained by the time the error surfaces, so the
 	// retry uses a fresh connection on the same provider.
 	maxConnDiedRetries = 2
+
+	// minAttemptTimeout is the floor (and default) for the per-attempt timeout
+	// that bounds dispatch + time-to-first-response-byte. Once response bytes
+	// start flowing, the rolling stall timeout takes over instead.
+	minAttemptTimeout = 2 * time.Second
+
+	// maxAttemptTimeout caps the adaptive per-attempt timeout derived from a
+	// provider's measured round-trip time.
+	maxAttemptTimeout = 10 * time.Second
+
+	// defaultStallTimeout is the rolling progress deadline applied to a body
+	// transfer once bytes are flowing: if no further bytes arrive within this
+	// window the connection is considered stalled and torn down. A healthy but
+	// slow transfer keeps extending the deadline and never trips it.
+	defaultStallTimeout = 8 * time.Second
+
+	// stallDeadlineQuantum coarsens stall-deadline updates so the read path
+	// issues at most one SetReadDeadline syscall per quantum instead of one per
+	// read.
+	stallDeadlineQuantum = 250 * time.Millisecond
+)
+
+// Attempt lifecycle states, coordinating the race between tryGroup's attempt
+// timer and the reader observing the first response byte. The CAS handshake
+// guarantees exactly one of them "wins": if the reader commits first the
+// attempt is never abandoned mid-stream; if the timer fires first the attempt
+// fails over and the reader drops the (cancelled) request.
+const (
+	attemptPending   int32 = iota // no response byte seen yet
+	attemptCommitted              // reader saw the first response byte
+	attemptAbandoned              // tryGroup timed out before any byte arrived
 )
 
 type greetingError struct {
@@ -108,6 +139,22 @@ type Request struct {
 	// sends nil after reading 340 (proceed to write body) or a non-nil error
 	// otherwise (e.g. 440 posting not allowed). Buffered with capacity 1.
 	postReadyCh chan error
+
+	// attemptDeadline bounds dispatch + time-to-first-response-byte for this
+	// attempt. Zero means no such bound (e.g. POST and keepalive requests).
+	// Once the reader sees the first byte the attempt is committed and this
+	// deadline no longer applies — the connection's rolling stall timeout does.
+	attemptDeadline time.Time
+
+	// attemptState is one of attemptPending/attemptCommitted/attemptAbandoned.
+	// The reader CASes pending→committed on the first response byte; tryGroup's
+	// timer CASes pending→abandoned on expiry. Zero value is attemptPending.
+	attemptState atomic.Int32
+
+	// sentAt is the Unix-nanosecond timestamp at which the payload was handed
+	// to the connection, used to measure time-to-first-byte. 0 = unset (the
+	// request is not measured, e.g. POST/keepalive).
+	sentAt atomic.Int64
 }
 
 type Response struct {
@@ -141,11 +188,11 @@ type NNTPConnection struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	reqCh      <-chan *Request
-	prioCh     <-chan *Request // priority channel; nil for standalone connections
-	hotReqCh   <-chan *Request // unbuffered; set by runConnSlot before Run()
-	hotPrioCh  <-chan *Request // unbuffered; set by runConnSlot before Run()
-	pending    chan *Request
+	reqCh     <-chan *Request
+	prioCh    <-chan *Request // priority channel; nil for standalone connections
+	hotReqCh  <-chan *Request // unbuffered; set by runConnSlot before Run()
+	hotPrioCh <-chan *Request // unbuffered; set by runConnSlot before Run()
+	pending   chan *Request
 
 	inflightSem chan struct{}
 
@@ -155,10 +202,11 @@ type NNTPConnection struct {
 
 	firstReq          *Request      // bootstrap request from connection slot
 	idleTimeout       time.Duration // 0 = no idle timeout
+	stallTimeout      time.Duration // rolling body-progress deadline; 0 = disabled
 	keepaliveInterval time.Duration // 0 = no keepalive
 	keepaliveCommand  string        // NNTP command for keepalive probe (e.g. "DATE")
 	providerName      string        // set by runConnSlot; used for error context
-	userAgent string
+	userAgent         string
 
 	stats *providerStats // nil for standalone connections
 
@@ -209,17 +257,17 @@ func newNNTPConnectionFromConn(ctx context.Context, conn net.Conn, inflightLimit
 	}
 
 	c := &NNTPConnection{
-		conn:              conn,
-		ctx:               cctx,
-		cancel:            cancel,
-		reqCh:             reqCh,
-		prioCh:            prioCh,
-		pending:           make(chan *Request, inflightLimit),
-		inflightSem:       make(chan struct{}, inflightLimit),
-		rb:                rb,
-		stats:             stats,
-		done:              make(chan struct{}),
-		userAgent: userAgent,
+		conn:        conn,
+		ctx:         cctx,
+		cancel:      cancel,
+		reqCh:       reqCh,
+		prioCh:      prioCh,
+		pending:     make(chan *Request, inflightLimit),
+		inflightSem: make(chan struct{}, inflightLimit),
+		rb:          rb,
+		stats:       stats,
+		done:        make(chan struct{}),
+		userAgent:   userAgent,
 	}
 
 	// Server greeting is sent immediately upon connect.
@@ -503,7 +551,7 @@ func (g *connGate) snapshot() (maxSlots, running int) {
 
 // runConnSlot is the slot goroutine that manages the lifecycle of a single
 // connection: IDLE → CONNECTING → ACTIVE → (death/idle) → IDLE.
-func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Request, hotReqCh <-chan *Request, hotPrioCh <-chan *Request, factory ConnFactory, inflight int, auth Auth, userAgent string, idleTimeout time.Duration, keepaliveInterval time.Duration, keepaliveCommand string, gate *connGate, stats *providerStats, providerName string, wg *sync.WaitGroup) {
+func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Request, hotReqCh <-chan *Request, hotPrioCh <-chan *Request, factory ConnFactory, inflight int, auth Auth, userAgent string, idleTimeout time.Duration, stallTimeout time.Duration, keepaliveInterval time.Duration, keepaliveCommand string, gate *connGate, stats *providerStats, providerName string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	// Shared read buffer persists across reconnections to avoid re-growing.
@@ -591,6 +639,7 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 		// ACTIVE: run the connection with the bootstrap request.
 		nc.firstReq = firstReq
 		nc.idleTimeout = idleTimeout
+		nc.stallTimeout = stallTimeout
 		nc.providerName = providerName
 		nc.hotReqCh = hotReqCh
 		nc.hotPrioCh = hotPrioCh
@@ -683,7 +732,7 @@ func (c *NNTPConnection) Run() {
 			return
 		}
 
-		dl, hasDL := req.Ctx.Deadline()
+		dl, hasDL := req.writeDeadline()
 		setWriteDeadline(dl, hasDL)
 
 		if _, err := bw.Write(req.Payload); err != nil {
@@ -739,6 +788,7 @@ func (c *NNTPConnection) Run() {
 					return
 				}
 			}
+			req.sentAt.Store(time.Now().UnixNano())
 			c.pending <- req
 		}
 	}
@@ -908,7 +958,7 @@ mainLoop:
 		}
 
 		// per-request write deadline (cached to avoid redundant syscalls)
-		dl, hasDL := req.Ctx.Deadline()
+		dl, hasDL := req.writeDeadline()
 		setWriteDeadline(dl, hasDL)
 
 		// pipeline write (buffered; flushed at top of loop before blocking)
@@ -966,6 +1016,7 @@ mainLoop:
 				}
 			}
 			// track FIFO ordering (after writes succeed to avoid send on closed channel)
+			req.sentAt.Store(time.Now().UnixNano())
 			c.pending <- req
 		}
 	}
@@ -1018,7 +1069,17 @@ func (c *NNTPConnection) readerLoop() {
 		// we are still draining the response.
 		outRef := &writerRef{w: out}
 
-		err := c.rb.feedUntilDone(c.conn, &decoder, outRef, func() (time.Time, bool) {
+		// Progress-aware deadline: before the first response byte we honor the
+		// attempt deadline (dispatch + TTFB bound); once bytes flow we switch to
+		// a rolling stall deadline that the wire progress keeps extending, so a
+		// healthy-but-slow body never trips it. The caller's own ctx deadline
+		// always still applies as an upper bound.
+		stall := c.stallTimeout
+		lastBytes := 0
+		var stallDeadline time.Time
+		var firstByteAt time.Time
+		respStart := time.Now()
+		err := c.rb.feedUntilDone(c.conn, &decoder, outRef, func(wireBytes int) (time.Time, bool) {
 			if deliver {
 				select {
 				case <-req.Ctx.Done():
@@ -1027,7 +1088,27 @@ func (c *NNTPConnection) readerLoop() {
 				default:
 				}
 			}
-			return req.Ctx.Deadline()
+			if wireBytes > lastBytes {
+				lastBytes = wireBytes
+				if firstByteAt.IsZero() {
+					firstByteAt = time.Now()
+				}
+				req.attemptState.CompareAndSwap(attemptPending, attemptCommitted)
+				if stall > 0 {
+					if dl := time.Now().Add(stall); dl.Sub(stallDeadline) >= stallDeadlineQuantum {
+						stallDeadline = dl
+					}
+				}
+			}
+			parentDL, hasParent := req.Ctx.Deadline()
+			switch {
+			case lastBytes == 0 && !req.attemptDeadline.IsZero():
+				return minDeadline(req.attemptDeadline, parentDL, hasParent)
+			case lastBytes > 0 && stall > 0:
+				return minDeadline(stallDeadline, parentDL, hasParent)
+			default:
+				return parentDL, hasParent
+			}
 		})
 		if err != nil {
 			if c.providerName != "" {
@@ -1051,7 +1132,7 @@ func (c *NNTPConnection) readerLoop() {
 					req.postReadyCh <- nil
 				}
 				decoder2 := NNTPResponse{}
-				err2 := c.rb.feedUntilDone(c.conn, &decoder2, io.Discard, func() (time.Time, bool) {
+				err2 := c.rb.feedUntilDone(c.conn, &decoder2, io.Discard, func(wireBytes int) (time.Time, bool) {
 					if deliver {
 						select {
 						case <-req.Ctx.Done():
@@ -1091,6 +1172,20 @@ func (c *NNTPConnection) readerLoop() {
 				c.stats.Missing.Add(1)
 			} else if decoder.StatusCode < 200 || decoder.StatusCode >= 400 {
 				c.stats.Errors.Add(1)
+			} else {
+				// Successful transfer: feed the TTFB and throughput EWMAs that
+				// drive the adaptive attempt timeout and speed-aware dispatch.
+				// firstByteAt is unset when the whole response arrived in a
+				// single read; fall back to the read start. recordTTFB/Speed
+				// ignore non-positive and sub-floor samples respectively.
+				fb := firstByteAt
+				if fb.IsZero() {
+					fb = respStart
+				}
+				if sentAt := req.sentAt.Load(); sentAt != 0 {
+					recordTTFB(c.stats, fb.Sub(time.Unix(0, sentAt)))
+				}
+				recordSpeed(c.stats, n, time.Since(fb))
 			}
 		}
 
@@ -1136,7 +1231,7 @@ func (c *NNTPConnection) readerLoop() {
 // Any unread bytes remain buffered in c.rbuf[c.rstart:c.rend] for subsequent reads.
 func (c *NNTPConnection) readOneResponse(out io.Writer) (NNTPResponse, error) {
 	resp := NNTPResponse{}
-	if err := c.rb.feedUntilDone(c.conn, &resp, out, func() (time.Time, bool) { return time.Time{}, false }); err != nil {
+	if err := c.rb.feedUntilDone(c.conn, &resp, out, func(int) (time.Time, bool) { return time.Time{}, false }); err != nil {
 		return resp, err
 	}
 	return resp, nil
@@ -1159,8 +1254,9 @@ const (
 type ClientOption func(*clientConfig)
 
 type clientConfig struct {
-	dispatch     DispatchStrategy
-	statProbeOff bool
+	dispatch      DispatchStrategy
+	statProbeOff  bool
+	speedAwareOff bool
 }
 
 // WithDispatchStrategy sets the request distribution strategy for main providers.
@@ -1179,6 +1275,15 @@ func WithStatProbe(enabled bool) ClientOption {
 	return func(cfg *clientConfig) { cfg.statProbeOff = !enabled }
 }
 
+// WithSpeedAwareDispatch enables or disables speed-aware weighting of the
+// DispatchRoundRobin strategy. When enabled (the default), each provider's
+// round-robin weight is scaled by its observed throughput so faster providers
+// receive proportionally more traffic; available connection capacity still
+// governs the base weight. Has no effect under DispatchFIFO.
+func WithSpeedAwareDispatch(enabled bool) ClientOption {
+	return func(cfg *clientConfig) { cfg.speedAwareOff = !enabled }
+}
+
 // Provider describes a single NNTP server with its own credentials and connection count.
 type Provider struct {
 	Host            string
@@ -1193,6 +1298,19 @@ type Provider struct {
 	ThrottleRestore time.Duration // 0 defaults to 30s
 	KeepAlive       time.Duration // TCP keep-alive interval; 0 defaults to 30s; negative disables
 	ReconnectDelay  time.Duration // 0 disables auto-reconnect after 502; when set, re-adds provider after this delay
+
+	// AttemptTimeout bounds dispatch plus time-to-first-response-byte for each
+	// attempt against this provider (it does NOT bound the body transfer, which
+	// is governed by StallTimeout). 0 selects an adaptive value derived from the
+	// provider's measured RTT, clamped to [2s, 10s]. Set explicitly to override.
+	AttemptTimeout time.Duration
+
+	// StallTimeout is the rolling progress deadline for a body transfer: once
+	// bytes are flowing, the read deadline is extended by StallTimeout on each
+	// chunk of progress, so a slow-but-healthy download never times out while a
+	// truly stalled one is torn down. 0 defaults to 8s; negative disables it
+	// (only the caller's context deadline applies).
+	StallTimeout time.Duration
 
 	// KeepaliveInterval, if non-zero, sends a lightweight NNTP command
 	// periodically when the connection is idle, to detect zombie connections
@@ -1231,23 +1349,46 @@ type Provider struct {
 }
 
 type providerGroup struct {
-	name     string
-	host     string // raw Provider.Host; empty for Factory-based providers
-	maxConns int
-	ctx      context.Context    // cancelled on removal/close
-	reqCh    chan *Request
-	prioCh   chan *Request // priority requests; connections prefer this over reqCh
+	name      string
+	host      string // raw Provider.Host; empty for Factory-based providers
+	maxConns  int
+	ctx       context.Context // cancelled on removal/close
+	reqCh     chan *Request
+	prioCh    chan *Request // priority requests; connections prefer this over reqCh
 	hotReqCh  chan *Request // unbuffered; hot (connected) connections read this
 	hotPrioCh chan *Request // unbuffered; hot priority connections read this
-	gate     *connGate
-	stats    providerStats
-	cancel   context.CancelFunc // cancels this group's slot goroutines
-	p        Provider           // original config; used for auto-reconnect
+	gate      *connGate
+	stats     providerStats
+	cancel    context.CancelFunc // cancels this group's slot goroutines
+	p         Provider           // original config; used for auto-reconnect
 
 	// Quota period configuration. quotaBytes/quotaUsed/quotaExceeded live in
 	// stats so that NNTPConnection can update them via its *providerStats pointer.
 	quotaPeriod  time.Duration // 0 = no auto-reset
 	quotaResetAt atomic.Int64  // Unix nanoseconds of next reset; 0 = never
+}
+
+// attemptTimeout returns the per-attempt timeout (dispatch + time-to-first-byte
+// bound). An explicit Provider.AttemptTimeout wins; otherwise it adapts to the
+// provider's observed time-to-first-byte EWMA (seeded from the ping RTT) as
+// 4×TTFB, clamped to [minAttemptTimeout, maxAttemptTimeout]. With no sample yet
+// it falls back to minAttemptTimeout, preserving the historical 2s behavior.
+func (g *providerGroup) attemptTimeout() time.Duration {
+	if g.p.AttemptTimeout > 0 {
+		return g.p.AttemptTimeout
+	}
+	ttfb := g.stats.ttfbEWMA.Load()
+	if ttfb <= 0 {
+		return minAttemptTimeout
+	}
+	d := time.Duration(ttfb) * 4
+	if d < minAttemptTimeout {
+		return minAttemptTimeout
+	}
+	if d > maxAttemptTimeout {
+		return maxAttemptTimeout
+	}
+	return d
 }
 
 // isQuotaExceeded reports whether this provider has consumed its download quota
@@ -1286,6 +1427,7 @@ type Client struct {
 
 	dispatch   DispatchStrategy // set once by NewClient, read-only after
 	statProbe  bool             // set once by NewClient; enables parallel STAT probing on 430
+	speedAware bool             // set once by NewClient; weights round-robin dispatch by throughput
 
 	providerIdx atomic.Int64 // monotonic counter for unnamed providers
 
@@ -1446,6 +1588,19 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 		pingCtx, pingCancel := context.WithTimeout(c.ctx, defaultHandshakeTimeout)
 		g.stats.Ping = pingProvider(pingCtx, factory, p.Auth)
 		pingCancel()
+		// Seed the TTFB EWMA from the measured RTT so the adaptive attempt
+		// timeout has a sensible starting point before any request completes.
+		if g.stats.Ping.Err == nil && g.stats.Ping.RTT > 0 {
+			g.stats.ttfbEWMA.Store(int64(g.stats.Ping.RTT))
+		}
+	}
+
+	// Resolve the rolling stall timeout: 0 => default, negative => disabled.
+	stall := p.StallTimeout
+	if stall == 0 {
+		stall = defaultStallTimeout
+	} else if stall < 0 {
+		stall = 0
 	}
 
 	// Resolve keepalive settings. If SkipPing is true and no explicit command
@@ -1464,7 +1619,7 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 
 	for range p.Connections {
 		c.wg.Add(1)
-		go runConnSlot(gctx, g.reqCh, g.prioCh, g.hotReqCh, g.hotPrioCh, factory, inflight, p.Auth, p.UserAgent, p.IdleTimeout, kaInterval, kaCmd, gate, &g.stats, name, &c.wg)
+		go runConnSlot(gctx, g.reqCh, g.prioCh, g.hotReqCh, g.hotPrioCh, factory, inflight, p.Auth, p.UserAgent, p.IdleTimeout, stall, kaInterval, kaCmd, gate, &g.stats, name, &c.wg)
 	}
 
 	return g
@@ -1514,11 +1669,12 @@ func NewClient(ctx context.Context, providers []Provider, opts ...ClientOption) 
 	}
 
 	c := &Client{
-		ctx:       ctx,
-		cancel:    cancel,
-		dispatch:  cfg.dispatch,
-		statProbe: !cfg.statProbeOff,
-		startTime: time.Now(),
+		ctx:        ctx,
+		cancel:     cancel,
+		dispatch:   cfg.dispatch,
+		statProbe:  !cfg.statProbeOff,
+		speedAware: !cfg.speedAwareOff,
+		startTime:  time.Now(),
 	}
 	// Initialize empty slices.
 	c.mainGroups.Store(&[]*providerGroup{})
@@ -1759,6 +1915,13 @@ func (c *Client) raceCandidates(
 		return false, false, lastErr
 	}
 	if resp.Err != nil {
+		// A committed attempt with a caller writer already streamed partial
+		// bytes; deliver the error rather than letting the caller re-stream
+		// into the same writer on another provider.
+		if bodyWriter != nil && attemptCommittedResp(resp) {
+			respCh <- resp
+			return true, false, nil
+		}
 		return false, false, resp.Err
 	}
 	if resp.StatusCode == 430 || resp.StatusCode == 423 {
@@ -1781,8 +1944,36 @@ func (c *Client) raceCandidates(
 	return true, false, lastErr
 }
 
+// minDeadline returns d, unless other is an earlier deadline (when hasOther),
+// in which case it returns other. The bool is always true (a deadline exists).
+func minDeadline(d, other time.Time, hasOther bool) (time.Time, bool) {
+	if hasOther && other.Before(d) {
+		return other, true
+	}
+	return d, true
+}
+
+// writeDeadline is the deadline used while writing the request payload: the
+// earlier of the caller's ctx deadline and the attempt deadline, so a dead
+// socket cannot hang the writer. Payloads are tiny, so the attempt deadline is
+// a safe upper bound.
+func (req *Request) writeDeadline() (time.Time, bool) {
+	dl, ok := req.Ctx.Deadline()
+	if !req.attemptDeadline.IsZero() && (!ok || req.attemptDeadline.Before(dl)) {
+		return req.attemptDeadline, true
+	}
+	return dl, ok
+}
+
 // tryGroup dispatches a single request to a provider group and waits for the
 // response. priority=true routes through the priority channels.
+//
+// The attempt timeout bounds only dispatch + time-to-first-response-byte, not
+// the whole body transfer: the request ctx carries no fixed deadline, and a
+// timer races the response. If the timer fires before any byte arrives the
+// attempt is abandoned (CAS pending→abandoned) and we fail over; if the reader
+// committed first (it saw a byte) we keep waiting for the body to finish, since
+// failing over after partial delivery would corrupt a caller's writer.
 func (c *Client) tryGroup(
 	ctx context.Context,
 	g *providerGroup,
@@ -1791,17 +1982,22 @@ func (c *Client) tryGroup(
 	onMeta func(YEncMeta),
 	priority bool,
 ) (resp Response, ok bool, done bool) {
-	attemptCtx, attemptCancel := context.WithTimeout(ctx, 2*time.Second)
-	defer attemptCancel()
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	defer reqCancel()
 
+	attemptTimeout := g.attemptTimeout()
 	innerCh := make(chan Response, 1)
 	req := &Request{
-		Ctx:        attemptCtx,
-		Payload:    payload,
-		RespCh:     innerCh,
-		BodyWriter: bodyWriter,
-		OnMeta:     onMeta,
+		Ctx:             reqCtx,
+		Payload:         payload,
+		RespCh:          innerCh,
+		BodyWriter:      bodyWriter,
+		OnMeta:          onMeta,
+		attemptDeadline: time.Now().Add(attemptTimeout),
 	}
+
+	timer := time.NewTimer(attemptTimeout)
+	defer timer.Stop()
 
 	var hotCh chan *Request
 	var coldCh chan *Request
@@ -1819,24 +2015,42 @@ func (c *Client) tryGroup(
 		select {
 		case <-c.ctx.Done():
 			return Response{}, false, true
-		case <-attemptCtx.Done():
+		case <-reqCtx.Done():
 			return Response{}, false, ctx.Err() != nil
 		case <-g.ctx.Done():
+			return Response{}, false, false
+		case <-timer.C:
+			// Could not be dispatched within the attempt window: the provider
+			// is saturated. Fail over.
 			return Response{}, false, false
 		case coldCh <- req:
 		}
 	}
 
-	select {
-	case resp, ok = <-innerCh:
-	case <-c.ctx.Done():
-		return Response{}, false, true
-	case <-attemptCtx.Done():
-		return Response{}, false, ctx.Err() != nil
-	case <-g.ctx.Done():
-		return Response{}, false, false
+	for {
+		select {
+		case resp, ok = <-innerCh:
+			return resp, ok, false
+		case <-c.ctx.Done():
+			return Response{}, false, true
+		case <-g.ctx.Done():
+			return Response{}, false, false
+		case <-reqCtx.Done():
+			return Response{}, false, ctx.Err() != nil
+		case <-timer.C:
+			if req.attemptState.CompareAndSwap(attemptPending, attemptAbandoned) {
+				// No response byte arrived in time: hung or too-slow to start.
+				// Cancel so the reader drops the request, and fail over.
+				reqCancel()
+				// done only when the caller's or the pool's context was
+				// cancelled (true shutdown), not on a plain attempt timeout.
+				return Response{}, false, ctx.Err() != nil || c.ctx.Err() != nil
+			}
+			// Reader already committed (first byte arrived): the body is
+			// streaming. Do not fail over; keep waiting for it to finish. The
+			// timer has fired and will not fire again.
+		}
 	}
-	return resp, ok, false
 }
 
 // hostSkipped reports whether host is already in the skip list.
@@ -1851,6 +2065,64 @@ func hostSkipped(host string, skipHosts *[4]string, count int) bool {
 		}
 	}
 	return false
+}
+
+// attemptCommittedResp reports whether the response came from an attempt that
+// had already started streaming bytes (the reader committed). Such an attempt
+// must not be retried or failed over when a caller-supplied writer is in use.
+func attemptCommittedResp(resp Response) bool {
+	return resp.Request != nil && resp.Request.attemptState.Load() == attemptCommitted
+}
+
+// maxSpeedScore is the highest multiplier speed-aware dispatch applies to a
+// provider's base (capacity) weight.
+const maxSpeedScore = 4
+
+// dispatchWeights computes cumulative round-robin weights for the given main
+// providers. The base weight is each provider's available connection capacity
+// (min 1 when live); quota-exceeded providers get weight 0. When speedAware is
+// true the base weight is scaled by speedScore so faster providers receive
+// proportionally more traffic. With no throughput samples this reduces to pure
+// capacity weighting (the historical behavior).
+func dispatchWeights(mains []*providerGroup, speedAware bool) (cum []int, total int) {
+	cum = make([]int, len(mains))
+	var maxSpeed float64
+	if speedAware {
+		for _, g := range mains {
+			if s := speedEWMABytesPerSec(&g.stats); s > maxSpeed {
+				maxSpeed = s
+			}
+		}
+	}
+	for i, g := range mains {
+		w := 0
+		if !g.isQuotaExceeded() {
+			w = max(1, int(g.gate.available.Load()))
+			if speedAware && maxSpeed > 0 {
+				w *= speedScore(speedEWMABytesPerSec(&g.stats), maxSpeed)
+			}
+		}
+		total += w
+		cum[i] = total
+	}
+	return cum, total
+}
+
+// speedScore maps a provider's throughput to an integer multiplier in
+// [1, maxSpeedScore] relative to the fastest provider. An unmeasured provider
+// (speed 0) scores the maximum so it is not starved before it has a sample.
+func speedScore(speed, maxSpeed float64) int {
+	if speed <= 0 {
+		return maxSpeedScore
+	}
+	s := int(float64(maxSpeedScore)*speed/maxSpeed + 0.5)
+	if s < 1 {
+		return 1
+	}
+	if s > maxSpeedScore {
+		return maxSpeedScore
+	}
+	return s
 }
 
 func (c *Client) sendWithRetry(ctx context.Context, payload []byte, bodyWriter io.Writer, onMeta func(YEncMeta), respCh chan Response) {
@@ -1876,6 +2148,13 @@ func (c *Client) tryGroupResilient(
 	for r := 0; ; r++ {
 		resp, ok, cancelled = c.tryGroup(ctx, g, payload, bodyWriter, onMeta, priority)
 		if cancelled || !ok {
+			return
+		}
+		// If the attempt already streamed bytes into the caller's writer, never
+		// retry: partial data was delivered and re-streaming would corrupt it.
+		// Buffered requests (bodyWriter == nil) keep their per-attempt buffer,
+		// so retrying them stays safe.
+		if bodyWriter != nil && attemptCommittedResp(resp) {
 			return
 		}
 		if r < maxConnDiedRetries && isConnectionDeathError(resp.Err) {
@@ -1927,19 +2206,9 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			}
 		}
 	default: // DispatchRoundRobin
-		// Dynamic weighted round-robin: each provider's weight equals
-		// its available capacity (allowed - held). Quota-exceeded providers
-		// get weight 0 so they are never selected during normal dispatch.
-		cumWeights := make([]int, n)
-		totalW := 0
-		for i, g := range mains {
-			avail := 0
-			if !g.isQuotaExceeded() {
-				avail = max(1, int(g.gate.available.Load()))
-			}
-			totalW += avail
-			cumWeights[i] = totalW
-		}
+		// Dynamic weighted round-robin. Quota-exceeded providers get weight 0
+		// so they are never selected during normal dispatch.
+		cumWeights, totalW := dispatchWeights(mains, c.speedAware)
 		if totalW == 0 {
 			// All providers are quota-exceeded; start at 0 and let the main
 			// loop below return ErrQuotaExceeded for each.
@@ -1974,6 +2243,13 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			continue
 		}
 		if resp.Err != nil {
+			// A committed attempt with a caller writer already streamed partial
+			// bytes; deliver the error rather than re-streaming into the same
+			// writer on another provider.
+			if bodyWriter != nil && attemptCommittedResp(resp) {
+				respCh <- resp
+				return
+			}
 			lastErr = resp.Err
 			continue
 		}
@@ -2074,6 +2350,13 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 				continue
 			}
 			if resp.Err != nil {
+				// A committed attempt with a caller writer already streamed
+				// partial bytes; deliver the error rather than re-streaming into
+				// the same writer on another provider.
+				if bodyWriter != nil && attemptCommittedResp(resp) {
+					respCh <- resp
+					return
+				}
 				lastErr = resp.Err
 				continue
 			}
@@ -2121,11 +2404,14 @@ func (c *Client) Stats() ClientStats {
 			quotaUsed := g.stats.quotaUsed.Load()
 			ps := ProviderStats{
 				Name:              g.name,
+				SpeedEWMA:         speedEWMABytesPerSec(&g.stats),
 				BytesConsumed:     consumed,
 				Missing:           g.stats.Missing.Load(),
 				Errors:            g.stats.Errors.Load(),
 				ActiveConnections: running,
 				MaxConnections:    maxSlots,
+				AvailableSlots:    int(g.gate.available.Load()),
+				TTFB:              time.Duration(g.stats.ttfbEWMA.Load()),
 				Ping:              g.stats.Ping,
 				QuotaBytes:        g.stats.quotaBytes,
 				QuotaUsed:         quotaUsed,

--- a/readBuffer.go
+++ b/readBuffer.go
@@ -105,15 +105,26 @@ func (rb *readBuffer) readMore(conn net.Conn, deadline time.Time, hasDeadline bo
 	return n, err
 }
 
-func (rb *readBuffer) feedUntilDone(conn net.Conn, feeder streamFeeder, out io.Writer, deadline func() (time.Time, bool)) error {
+// feedUntilDone streams a response off the wire into out, decoding via feeder.
+//
+// deadline is consulted before every read; it receives wireBytes, the
+// cumulative number of bytes already read from conn during this call. This
+// lets callers distinguish "still waiting for the first response byte" (a
+// time-to-first-byte bound) from "bytes are flowing" (a rolling progress/stall
+// bound), and to detect progress even when the decoder consumes 0 bytes from a
+// partial line.
+func (rb *readBuffer) feedUntilDone(conn net.Conn, feeder streamFeeder, out io.Writer, deadline func(wireBytes int) (time.Time, bool)) error {
 	rb.init()
+	wireBytes := 0
 
 	for {
 		// Ensure we have some bytes to feed.
 		if rb.start == rb.end {
 			rb.start, rb.end = 0, 0
-			dl, ok := deadline()
-			if _, err := rb.readMore(conn, dl, ok); err != nil {
+			dl, ok := deadline(wireBytes)
+			n, err := rb.readMore(conn, dl, ok)
+			wireBytes += n
+			if err != nil {
 				return err
 			}
 		}
@@ -136,8 +147,10 @@ func (rb *readBuffer) feedUntilDone(conn net.Conn, feeder streamFeeder, out io.W
 			rb.compact()
 		}
 
-		dl, ok := deadline()
-		if _, err := rb.readMore(conn, dl, ok); err != nil {
+		dl, ok := deadline(wireBytes)
+		n, err := rb.readMore(conn, dl, ok)
+		wireBytes += n
+		if err != nil {
 			return err
 		}
 	}

--- a/readbuffer_test.go
+++ b/readbuffer_test.go
@@ -235,7 +235,7 @@ func TestReadBuffer_FeedUntilDone(t *testing.T) {
 			},
 		}
 
-		err := rb.feedUntilDone(client, feeder, io.Discard, func() (time.Time, bool) {
+		err := rb.feedUntilDone(client, feeder, io.Discard, func(int) (time.Time, bool) {
 			return time.Time{}, false
 		})
 		if err != nil {
@@ -266,7 +266,7 @@ func TestReadBuffer_FeedUntilDone(t *testing.T) {
 			},
 		}
 
-		err := rb.feedUntilDone(client, feeder, io.Discard, func() (time.Time, bool) {
+		err := rb.feedUntilDone(client, feeder, io.Discard, func(int) (time.Time, bool) {
 			return time.Time{}, false
 		})
 		if err != nil {
@@ -293,7 +293,7 @@ func TestReadBuffer_FeedUntilDone(t *testing.T) {
 			},
 		}
 
-		err := rb.feedUntilDone(client, feeder, io.Discard, func() (time.Time, bool) {
+		err := rb.feedUntilDone(client, feeder, io.Discard, func(int) (time.Time, bool) {
 			return time.Time{}, false
 		})
 		if err != io.ErrUnexpectedEOF {
@@ -315,7 +315,7 @@ func TestReadBuffer_FeedUntilDone(t *testing.T) {
 			},
 		}
 
-		err := rb.feedUntilDone(client, feeder, io.Discard, func() (time.Time, bool) {
+		err := rb.feedUntilDone(client, feeder, io.Discard, func(int) (time.Time, bool) {
 			return time.Time{}, false
 		})
 		_ = client.Close()
@@ -348,7 +348,7 @@ func TestReadBuffer_FeedUntilDone(t *testing.T) {
 			},
 		}
 
-		err := rb.feedUntilDone(client, feeder, io.Discard, func() (time.Time, bool) {
+		err := rb.feedUntilDone(client, feeder, io.Discard, func(int) (time.Time, bool) {
 			return time.Time{}, false
 		})
 		if err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -206,7 +206,7 @@ func TestFeed_ByteAtATime(t *testing.T) {
 	r := &NNTPResponse{}
 	var decoded bytes.Buffer
 	var rb readBuffer
-	err := rb.feedUntilDone(client, r, &decoded, func() (time.Time, bool) {
+	err := rb.feedUntilDone(client, r, &decoded, func(int) (time.Time, bool) {
 		return time.Time{}, false
 	})
 	if err != nil {
@@ -701,7 +701,7 @@ func TestFeed_ProtocolDesyncReaderLoop(t *testing.T) {
 
 	rb := readBuffer{}
 	resp := NNTPResponse{}
-	err := rb.feedUntilDone(client, &resp, io.Discard, func() (time.Time, bool) {
+	err := rb.feedUntilDone(client, &resp, io.Discard, func(int) (time.Time, bool) {
 		return time.Time{}, false
 	})
 	if err != ErrProtocolDesync {

--- a/stability_test.go
+++ b/stability_test.go
@@ -1,0 +1,490 @@
+package nntppool
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// writeChunked writes b to conn in n roughly-equal chunks, sleeping gap between
+// each. net.Pipe is unbuffered, so each Write blocks until the client reads,
+// which faithfully simulates a slow trickle on the wire.
+func writeChunked(conn net.Conn, b []byte, n int, gap time.Duration) {
+	if n < 1 {
+		n = 1
+	}
+	step := (len(b) + n - 1) / n
+	for off := 0; off < len(b); off += step {
+		end := min(off+step, len(b))
+		if _, err := conn.Write(b[off:end]); err != nil {
+			return
+		}
+		if off+step < len(b) {
+			time.Sleep(gap)
+		}
+	}
+}
+
+// TestSlowBodySucceeds is the regression test for the per-attempt-timeout bug:
+// a body that takes longer than the attempt timeout to download must still
+// succeed (the attempt timeout only bounds dispatch + time-to-first-byte, not
+// the whole transfer), on a single connection with no churn.
+func TestSlowBodySucceeds(t *testing.T) {
+	payload := bytes.Repeat([]byte("abcdefghij"), 4096) // 40 KiB
+	full := yencSinglePart(payload, "slow.bin")
+
+	var dials atomic.Int64
+	factory := func(ctx context.Context) (net.Conn, error) {
+		dials.Add(1)
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				if strings.HasPrefix(string(buf[:n]), "BODY") {
+					// ~10 chunks, 60ms apart => ~540ms total, far beyond the
+					// 200ms attempt timeout but well within the stall timeout.
+					writeChunked(server, full, 10, 60*time.Millisecond)
+				}
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: factory, Connections: 1, SkipPing: true, AttemptTimeout: 200 * time.Millisecond},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	body, err := c.Body(context.Background(), "id@test")
+	if err != nil {
+		t.Fatalf("Body() error = %v, want success for a slow-but-healthy transfer", err)
+	}
+	if !bytes.Equal(body.Bytes, payload) {
+		t.Fatalf("Body() bytes mismatch: got %d bytes, want %d", len(body.Bytes), len(payload))
+	}
+	if got := dials.Load(); got != 1 {
+		t.Errorf("dials = %d, want 1 (no connection churn)", got)
+	}
+}
+
+// TestHungProviderFailsOverFast verifies that a provider which accepts the
+// command but never responds is abandoned within the attempt timeout and the
+// request succeeds on the next provider.
+func TestHungProviderFailsOverFast(t *testing.T) {
+	payload := bytes.Repeat([]byte("Z"), 1024)
+	full := yencSinglePart(payload, "ok.bin")
+
+	hung := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			_, _ = server.Read(buf) // read the command, then never respond
+			<-ctx.Done()
+			_ = server.Close()
+		}()
+		return client, nil
+	}
+	healthy := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				if strings.HasPrefix(string(buf[:n]), "BODY") {
+					_, _ = server.Write(full)
+				}
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: hung, Connections: 1, SkipPing: true, AttemptTimeout: 200 * time.Millisecond},
+		{Factory: healthy, Connections: 1, SkipPing: true, AttemptTimeout: 200 * time.Millisecond},
+	}, WithDispatchStrategy(DispatchFIFO))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	start := time.Now()
+	body, err := c.Body(context.Background(), "id@test")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Body() error = %v, want failover to healthy provider", err)
+	}
+	if !bytes.Equal(body.Bytes, payload) {
+		t.Fatalf("Body() bytes mismatch: got %d bytes, want %d", len(body.Bytes), len(payload))
+	}
+	if elapsed > time.Second {
+		t.Errorf("failover took %v, want < 1s (≈ attempt timeout)", elapsed)
+	}
+}
+
+// TestMidBodyStallStreamErrors verifies that when a streamed transfer stalls
+// after delivering partial bytes, the caller gets an error (rather than the
+// pool silently re-streaming into the same writer on another provider).
+func TestMidBodyStallStreamErrors(t *testing.T) {
+	payload := bytes.Repeat([]byte("Q"), 64*1024)
+	full := yencSinglePart(payload, "stall.bin")
+	half := full[:len(full)/2]
+
+	stalling := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				if strings.HasPrefix(string(buf[:n]), "BODY") {
+					_, _ = server.Write(half) // partial, then hang
+					<-ctx.Done()
+					_ = server.Close()
+					return
+				}
+			}
+		}()
+		return client, nil
+	}
+	healthy := makeBodyFactory(t, 200)
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: stalling, Connections: 1, SkipPing: true, AttemptTimeout: 200 * time.Millisecond, StallTimeout: 250 * time.Millisecond},
+		{Factory: healthy, Connections: 1, SkipPing: true},
+	}, WithDispatchStrategy(DispatchFIFO))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	var sink bytes.Buffer
+	_, err = c.BodyStream(context.Background(), "id@test", &sink)
+	if err == nil {
+		t.Fatal("BodyStream() error = nil, want stall error (no silent failover after partial stream)")
+	}
+	if sink.Len() >= len(payload) {
+		t.Errorf("sink has %d bytes, want a partial (<%d) stream with no duplication", sink.Len(), len(payload))
+	}
+}
+
+// TestStatProbeWinnerStallStreamErrors covers the STAT-probe failover path:
+// when the probe winner stalls mid-body after partial delivery to a caller's
+// writer, the error must surface rather than the pool re-streaming into the
+// same writer on a later provider.
+func TestStatProbeWinnerStallStreamErrors(t *testing.T) {
+	payload := bytes.Repeat([]byte("W"), 64*1024)
+	full := yencSinglePart(payload, "win.bin")
+	half := full[:len(full)/2]
+
+	// answers maps command prefix -> handler.
+	serve := func(onBody func(net.Conn), onStat string) ConnFactory {
+		return func(ctx context.Context) (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				_, _ = server.Write([]byte("200 ready\r\n"))
+				buf := make([]byte, 4096)
+				for {
+					n, err := server.Read(buf)
+					if err != nil {
+						return
+					}
+					cmd := string(buf[:n])
+					switch {
+					case strings.HasPrefix(cmd, "STAT"):
+						_, _ = server.Write([]byte(onStat))
+					case strings.HasPrefix(cmd, "BODY"):
+						if onBody != nil {
+							onBody(server)
+							return
+						}
+						_, _ = server.Write([]byte("430 no such article\r\n"))
+					}
+				}
+			}()
+			return client, nil
+		}
+	}
+
+	// A: 430 on BODY (triggers the race). B: STAT 223 winner, stalls on BODY.
+	// C: STAT 430 miss (so B is the deterministic winner) + healthy BODY.
+	provA := serve(nil, "430 no\r\n")
+	provB := serve(func(s net.Conn) {
+		_, _ = s.Write(half) // partial, then hang until the conn is torn down
+		time.Sleep(2 * time.Second)
+		_ = s.Close()
+	}, "223 1 <id@test> exists\r\n")
+	provC := serve(func(s net.Conn) {
+		_, _ = s.Write(full)
+	}, "430 no\r\n")
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: provA, Connections: 1, SkipPing: true, AttemptTimeout: 200 * time.Millisecond},
+		{Factory: provB, Connections: 1, SkipPing: true, AttemptTimeout: 200 * time.Millisecond, StallTimeout: 250 * time.Millisecond},
+		{Factory: provC, Connections: 1, SkipPing: true},
+	}, WithDispatchStrategy(DispatchFIFO))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	var sink bytes.Buffer
+	_, err = c.BodyStream(context.Background(), "id@test", &sink)
+	if err == nil {
+		t.Fatal("BodyStream() error = nil, want stall error (no re-stream onto provider C)")
+	}
+	if sink.Len() >= len(payload) {
+		t.Errorf("sink has %d bytes, want partial (<%d) with no duplication", sink.Len(), len(payload))
+	}
+}
+
+// TestBufferedStallRecovers verifies that a buffered (non-streaming) request
+// that stalls on one provider recovers by failing over to a healthy provider,
+// since the per-attempt buffer makes retrying safe.
+func TestBufferedStallRecovers(t *testing.T) {
+	payload := bytes.Repeat([]byte("M"), 1024)
+	full := yencSinglePart(payload, "ok.bin")
+
+	stalling := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				if strings.HasPrefix(string(buf[:n]), "BODY") {
+					_, _ = server.Write([]byte("222 0 <id@test> body\r\n=ybegin ")) // partial header, then hang
+					<-ctx.Done()
+					_ = server.Close()
+					return
+				}
+			}
+		}()
+		return client, nil
+	}
+	healthy := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				if strings.HasPrefix(string(buf[:n]), "BODY") {
+					_, _ = server.Write(full)
+				}
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: stalling, Connections: 1, SkipPing: true, AttemptTimeout: 200 * time.Millisecond, StallTimeout: 200 * time.Millisecond},
+		{Factory: healthy, Connections: 1, SkipPing: true},
+	}, WithDispatchStrategy(DispatchFIFO))
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	body, err := c.Body(context.Background(), "id@test")
+	if err != nil {
+		t.Fatalf("Body() error = %v, want recovery via healthy provider", err)
+	}
+	if !bytes.Equal(body.Bytes, payload) {
+		t.Fatalf("Body() bytes mismatch: got %d bytes, want %d", len(body.Bytes), len(payload))
+	}
+}
+
+// TestAttemptTimeoutMethod covers the adaptive per-attempt timeout selection.
+func TestAttemptTimeoutMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		explicit time.Duration
+		ttfb     time.Duration
+		want     time.Duration
+	}{
+		{"explicit override wins", 3 * time.Second, 50 * time.Millisecond, 3 * time.Second},
+		{"no sample falls back to floor", 0, 0, minAttemptTimeout},
+		{"tiny rtt clamps to floor", 0, 10 * time.Millisecond, minAttemptTimeout},
+		{"mid rtt scales by 4x", 0, time.Second, 4 * time.Second},
+		{"huge rtt clamps to cap", 0, 5 * time.Second, maxAttemptTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &providerGroup{p: Provider{AttemptTimeout: tt.explicit}}
+			if tt.ttfb > 0 {
+				g.stats.ttfbEWMA.Store(int64(tt.ttfb))
+			}
+			if got := g.attemptTimeout(); got != tt.want {
+				t.Errorf("attemptTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecordTTFB covers the EWMA update and the "not measured" guards.
+func TestRecordTTFB(t *testing.T) {
+	var s providerStats
+	recordTTFB(&s, 0)            // non-positive: ignored
+	recordTTFB(&s, -time.Second) // negative: ignored
+	if s.ttfbEWMA.Load() != 0 {
+		t.Fatalf("ttfbEWMA = %d, want 0 for unmeasured sample", s.ttfbEWMA.Load())
+	}
+	recordTTFB(nil, time.Second) // nil stats: no panic
+
+	recordTTFB(&s, 100*time.Millisecond)
+	if got := s.ttfbEWMA.Load(); got != int64(100*time.Millisecond) {
+		t.Fatalf("ttfbEWMA = %d, want first sample stored directly", got)
+	}
+	// Second sample moves the average toward it (EWMA, α=0.2).
+	recordTTFB(&s, 200*time.Millisecond)
+	if got := s.ttfbEWMA.Load(); got <= int64(100*time.Millisecond) || got >= int64(200*time.Millisecond) {
+		t.Fatalf("ttfbEWMA = %d, want between 100ms and 200ms", got)
+	}
+}
+
+// TestRecordSpeed covers the throughput EWMA and the small-sample floor.
+func TestRecordSpeed(t *testing.T) {
+	var s providerStats
+	recordSpeed(&s, speedSampleFloor-1, time.Second) // below floor: ignored
+	if s.speedEWMA.Load() != 0 {
+		t.Fatal("speedEWMA updated for a sub-floor sample")
+	}
+	recordSpeed(&s, 1_000_000, time.Second) // 1 MB/s
+	if speedEWMABytesPerSec(&s) <= 0 {
+		t.Fatal("speedEWMA not updated for a valid sample")
+	}
+}
+
+// TestStatsExposesNewFields verifies TTFB, SpeedEWMA and AvailableSlots are
+// populated in Stats() after a successful body transfer.
+func TestStatsExposesNewFields(t *testing.T) {
+	payload := bytes.Repeat([]byte("S"), 64*1024) // above speedSampleFloor
+	full := yencSinglePart(payload, "stats.bin")
+	factory := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				if strings.HasPrefix(string(buf[:n]), "BODY") {
+					_, _ = server.Write(full)
+				}
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: factory, Connections: 2, SkipPing: true},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if _, err := c.Body(context.Background(), "id@test"); err != nil {
+		t.Fatalf("Body() error = %v", err)
+	}
+
+	st := c.Stats()
+	if len(st.Providers) != 1 {
+		t.Fatalf("Providers = %d, want 1", len(st.Providers))
+	}
+	ps := st.Providers[0]
+	if ps.SpeedEWMA <= 0 {
+		t.Errorf("SpeedEWMA = %v, want > 0 after a >16KiB transfer", ps.SpeedEWMA)
+	}
+	if ps.TTFB <= 0 {
+		t.Errorf("TTFB = %v, want > 0", ps.TTFB)
+	}
+	if ps.AvailableSlots < 0 || ps.AvailableSlots > ps.MaxConnections {
+		t.Errorf("AvailableSlots = %d, want within [0, %d]", ps.AvailableSlots, ps.MaxConnections)
+	}
+}
+
+// newWeightGroup builds a minimal providerGroup with the given available-slot
+// count and (optional) throughput sample, for dispatchWeights tests.
+func newWeightGroup(avail int32, speed float64) *providerGroup {
+	g := &providerGroup{gate: newConnGate(int(avail), 0)}
+	g.gate.available.Store(avail)
+	if speed > 0 {
+		recordSpeed(&g.stats, int64(speed), time.Second)
+	}
+	return g
+}
+
+func TestDispatchWeights(t *testing.T) {
+	t.Run("no samples reduces to capacity weighting", func(t *testing.T) {
+		mains := []*providerGroup{newWeightGroup(2, 0), newWeightGroup(3, 0)}
+		cum, total := dispatchWeights(mains, true)
+		// No provider has a throughput sample => maxSpeed 0 => pure capacity.
+		if total != 5 || cum[0] != 2 || cum[1] != 5 {
+			t.Fatalf("cum = %v, total = %d, want [2 5], 5", cum, total)
+		}
+	})
+
+	t.Run("slow provider gets a smaller share", func(t *testing.T) {
+		fast := newWeightGroup(1, 4_000_000) // 4 MB/s
+		slow := newWeightGroup(1, 1_000_000) // 1 MB/s
+		mains := []*providerGroup{fast, slow}
+		_, total := dispatchWeights(mains, true)
+		// fast: 1*4, slow: 1*round(4*1/4)=1*1 => 5 total.
+		if total != 5 {
+			t.Fatalf("total = %d, want 5 (fast 4 + slow 1)", total)
+		}
+	})
+
+	t.Run("speedAware off ignores throughput", func(t *testing.T) {
+		fast := newWeightGroup(1, 4_000_000)
+		slow := newWeightGroup(1, 1_000_000)
+		_, total := dispatchWeights([]*providerGroup{fast, slow}, false)
+		if total != 2 {
+			t.Fatalf("total = %d, want 2 (pure capacity)", total)
+		}
+	})
+
+	t.Run("quota-exceeded provider gets zero weight", func(t *testing.T) {
+		g := newWeightGroup(2, 0)
+		g.stats.quotaBytes = 100
+		g.stats.quotaUsed.Store(100)
+		g.stats.quotaExceeded.Store(true)
+		_, total := dispatchWeights([]*providerGroup{g}, true)
+		if total != 0 {
+			t.Fatalf("total = %d, want 0 for quota-exceeded provider", total)
+		}
+	})
+}


### PR DESCRIPTION
## Context

The per-attempt timeout introduced in #69 was applied to the **entire body transfer** (it became the connection read deadline), so any article taking longer than 2s to download tripped the deadline, tore down the connection, and failed over repeatedly — causing connection churn and throughput collapse on slow links. This PR fixes that and adds adaptive timeouts, speed-aware dispatch, and observability.

## What changed

### Stall-aware timeouts (the fix)
- The attempt timeout now bounds **only dispatch + time-to-first-response-byte**, not the whole transfer.
- Once bytes flow, a **rolling stall deadline** (`Provider.StallTimeout`, default 8s) governs the body and is extended on every chunk of wire progress — a healthy-but-slow download never times out, while a genuinely stalled one is still torn down.
- A lock-free CAS handshake on the request's attempt state coordinates the attempt timer (abandon) with the reader (commit on first byte). A **committed** stream is never failed over onto a caller-supplied writer, so partial bytes are never re-streamed/duplicated.

### Adaptive attempt timeout
- `clamp(4×TTFB_EWMA, 2s, 10s)`, seeded from the startup ping RTT. `Provider.AttemptTimeout` overrides explicitly. Floor equals the previous fixed value, so it's strictly more tolerant.

### Speed-aware dispatch
- `DispatchRoundRobin` weights now scale by a per-provider throughput EWMA so faster providers receive proportionally more traffic. Capacity weighting still sets the base. `WithSpeedAwareDispatch(false)` opts out; with no samples it reduces to the previous capacity-only behavior.

### Observability
- `ProviderStats` now exposes `TTFB`, `SpeedEWMA`, and `AvailableSlots`.

## Compatibility
Public API is backward compatible. New `Provider`/`Client` knobs are optional with sane defaults. The internal `feedUntilDone` deadline callback now receives cumulative wire-progress bytes to distinguish TTFB from mid-body stalls.

## Reviewer notes
- Concurrency-sensitive: the attempt-state CAS handshake is the crux — review `tryGroup`, `readerLoop`'s progress-aware deadline closure, and the committed-failure guards in `doSendWithRetry`/`tryGroupResilient`/`raceCandidates`.
- The STAT-probe winner path (`raceCandidates`) also carries the committed-failure guard so a stalled probe winner doesn't re-stream onto a later provider.

## Tests
New `stability_test.go` covers:
- slow body succeeds with no connection churn (the regression),
- fast failover on a hung provider,
- mid-body stall surfaces an error without re-streaming (direct **and** STAT-probe-winner paths),
- buffered-stall recovery via a healthy provider,
- TTFB/speed EWMA math and dispatch-weight unit tests, plus a `Stats()` field check.

`make check` (generate + tidy + golangci-lint + `-race` tests) is green; timing tests verified non-flaky over repeated runs.