### PR TITLE
feat(stat): bulk StatMany, async/priority variants, and deep STAT pipeline lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,75 @@ if errors.Is(err, nntppool.ErrArticleNotFound) {
 }
 ```
 
+`StatPriority` is the same check dispatched via the priority queue (prefers idle
+connections, so a one-off check doesn't queue behind a large BODY). `StatAsync`
+returns a channel for a single non-blocking check.
+
+### Bulk existence checks (NZB health checks)
+
+`STAT` is a single-line request with a single-line reply and **no body**, so it is
+purely round-trip-latency bound — the ideal command to run massively in parallel.
+`StatMany` checks a slice of message-IDs concurrently, streaming a result per ID as
+each completes (out of order), and closes the channel when done. A genuine miss is
+reported as `ErrArticleNotFound` with a nil `Result` — a normal outcome of a sweep,
+not a fatal error:
+
+```go
+ids := nzb.SegmentMessageIDs() // e.g. thousands of segments
+var have, missing int
+for r := range client.StatMany(ctx, ids, nntppool.StatManyOptions{Concurrency: 64}) {
+    switch {
+    case r.Err == nil:
+        have++
+    case errors.Is(r.Err, nntppool.ErrArticleNotFound):
+        missing++
+    default:
+        log.Printf("%s: %v", r.MessageID, r.Err)
+    }
+}
+fmt.Printf("availability: %d/%d present\n", have, have+missing)
+```
+
+`StatManyOptions`:
+
+| Field | Description |
+|-------|-------------|
+| `Concurrency` | Max STATs outstanding across the whole pool at once (0 ⇒ 64). |
+| `Priority` | Route each STAT through the priority queue. |
+| `Provider` | Restrict every STAT to one named provider group (per-provider availability audit). Empty ⇒ pool-wide with the same failover as `Stat`. |
+
+If `ctx` is cancelled mid-sweep, dispatch stops and in-flight checks are cancelled;
+IDs not yet dispatched produce no result, so check `ctx.Err()` after draining.
+
+#### Tuning STAT throughput
+
+Two levers, both usenet-informed:
+
+- **Fan-out across connections** — handled for you: `StatMany` spreads checks over
+  every connection via the pool's weighted round-robin. More `Connections` ⇒ more
+  parallel checks.
+- **Pipeline depth per connection** — set `Provider.StatInflight` higher than
+  `Inflight`. Because STAT carries no payload, many checks can be in flight on one
+  connection at negligible memory cost, amortising the round-trip. `Inflight`
+  bounds concurrent **BODY** responses (keep it modest — `5`–`10` — to cap
+  download memory), while `StatInflight` independently sets how deep bodyless
+  **STAT** commands pipeline. A general-purpose client can therefore run
+  `Inflight: 8, StatInflight: 100`: downloads stay bounded, existence sweeps go
+  fast — no separate client needed.
+
+  ```go
+  nntppool.Provider{
+      Host:         "news.example.com:563",
+      Connections:  20,
+      Inflight:     8,   // max concurrent BODY per connection
+      StatInflight: 100, // STAT pipelines this deep (0 ⇒ same as Inflight)
+  }
+  ```
+
+  Caveat: replies on a connection are read in order (FIFO), so a STAT queued
+  behind an in-progress BODY on the *same* connection waits for that BODY. A pure
+  STAT sweep has no bodies in the way and reaches the full `StatInflight` depth.
+
 ### Fetch article headers
 
 ```go
@@ -661,6 +730,9 @@ Provider names default to `host:port` or `host:port+username` (when auth is set)
 | `BodyPriority` | `(ctx, messageID, onMeta...) (*ArticleBody, error)` | Like `Body` but dispatched via the priority queue |
 | `Head` | `(ctx, messageID) (*ArticleHead, error)` | Fetch RFC 5322 headers; returns parsed `map[string][]string` with folding resolved |
 | `Stat` | `(ctx, messageID) (*StatResult, error)` | Check article existence without transferring body |
+| `StatPriority` | `(ctx, messageID) (*StatResult, error)` | Like `Stat` but dispatched via the priority queue |
+| `StatAsync` | `(ctx, messageID) <-chan StatManyResult` | Non-blocking single existence check; channel receives exactly one result |
+| `StatMany` | `(ctx, messageIDs, StatManyOptions) <-chan StatManyResult` | Concurrent bulk existence check; streams one result per ID as it completes |
 
 The `onMeta` optional callback is called once `=ybegin`/`=ypart` is fully parsed (before any body bytes), enabling pre-allocation or filename routing.
 
@@ -785,7 +857,8 @@ type ProviderStats struct {
 | `TLSConfig` | `*tls.Config` | nil (plain TCP) | Pass a `tls.Config` to enable TLS; set `ServerName` for SNI |
 | `Auth` | `Auth` | — | `Username` and `Password` for AUTHINFO handshake |
 | `Connections` | `int` | — | **Required.** Number of connection slots for this provider |
-| `Inflight` | `int` | 1 | Max pipelined NNTP commands per connection |
+| `Inflight` | `int` | 1 | Max concurrent BODY (and other body-bearing) commands per connection |
+| `StatInflight` | `int` | 0 (= `Inflight`) | Pipeline depth for bodyless STAT commands; set higher than `Inflight` (e.g. 50–100) to amortise round-trips on existence sweeps without inflating BODY memory |
 | `Factory` | `ConnFactory` | nil | Custom dialer `func(ctx) (net.Conn, error)`; overrides `Host`/`TLSConfig` |
 | `Backup` | `bool` | false | If true, only used when all main providers return 430 |
 | `SkipPing` | `bool` | false | Skip the startup DATE ping (for servers that don't support DATE) |

--- a/client.go
+++ b/client.go
@@ -144,12 +144,15 @@ func (c *Client) Head(ctx context.Context, messageID string) (*ArticleHead, erro
 	}, nil
 }
 
-// Stat checks whether an article exists without transferring its contents.
-func (c *Client) Stat(ctx context.Context, messageID string) (*StatResult, error) {
-	payload := []byte("STAT <" + messageID + ">\r\n")
-	respCh := c.Send(ctx, payload, nil)
+// statPayload builds the wire payload for a STAT command.
+func statPayload(messageID string) []byte {
+	return []byte("STAT <" + messageID + ">\r\n")
+}
 
-	resp := <-respCh
+// parseStat maps a STAT Response to a StatResult. A 430/423 (article not found)
+// is returned as ErrArticleNotFound with a nil result; callers doing bulk
+// existence checks treat that as a normal miss rather than a fatal error.
+func parseStat(messageID string, resp Response) (*StatResult, error) {
 	if resp.Err != nil {
 		return nil, resp.Err
 	}
@@ -169,6 +172,32 @@ func (c *Client) Stat(ctx context.Context, messageID string) (*StatResult, error
 	}
 
 	return result, nil
+}
+
+// Stat checks whether an article exists without transferring its contents.
+func (c *Client) Stat(ctx context.Context, messageID string) (*StatResult, error) {
+	return parseStat(messageID, <-c.Send(ctx, statPayload(messageID), nil))
+}
+
+// StatPriority is like Stat but enqueues on the priority channel so idle
+// connections pick it up before normal requests. Useful for a latency-sensitive
+// existence check that must not queue behind a large BODY on a busy connection.
+func (c *Client) StatPriority(ctx context.Context, messageID string) (*StatResult, error) {
+	return parseStat(messageID, <-c.SendPriority(ctx, statPayload(messageID), nil))
+}
+
+// StatAsync returns a channel that will receive exactly one StatManyResult,
+// mirroring BodyAsync. It preserves the fan-out pattern used by BodyAsync so a
+// caller can dispatch many existence checks and collect them concurrently. For
+// checking a slice of message-IDs prefer StatMany, which bounds concurrency.
+func (c *Client) StatAsync(ctx context.Context, messageID string) <-chan StatManyResult {
+	ch := make(chan StatManyResult, 1)
+	go func() {
+		res, err := c.Stat(ctx, messageID)
+		ch <- StatManyResult{MessageID: messageID, Result: res, Err: err}
+		close(ch)
+	}()
+	return ch
 }
 
 // doBody is the shared implementation for Body, BodyStream, and BodyAsync.

--- a/nntp.go
+++ b/nntp.go
@@ -155,6 +155,11 @@ type Request struct {
 	// to the connection, used to measure time-to-first-byte. 0 = unset (the
 	// request is not measured, e.g. POST/keepalive).
 	sentAt atomic.Int64
+
+	// heldBody is set by writeLoop when this (body-bearing) request acquired a
+	// bodySem slot, so readerLoop releases exactly the slots that were taken.
+	// Bodyless STAT requests never acquire bodySem and leave this false.
+	heldBody bool
 }
 
 type Response struct {
@@ -194,7 +199,14 @@ type NNTPConnection struct {
 	hotPrioCh <-chan *Request // unbuffered; set by runConnSlot before Run()
 	pending   chan *Request
 
+	// inflightSem bounds the total pipeline depth (cap = StatInflight, i.e.
+	// max(Inflight, StatInflight)). bodySem additionally bounds concurrent
+	// body-bearing commands (cap = Inflight) so raising the STAT pipeline depth
+	// never increases the number of BODY responses buffered/streamed at once.
+	// Bodyless STAT commands acquire only inflightSem and so pipeline to the
+	// deeper StatInflight depth.
 	inflightSem chan struct{}
+	bodySem     chan struct{}
 
 	rb readBuffer
 
@@ -264,10 +276,14 @@ func newNNTPConnectionFromConn(ctx context.Context, conn net.Conn, inflightLimit
 		prioCh:      prioCh,
 		pending:     make(chan *Request, inflightLimit),
 		inflightSem: make(chan struct{}, inflightLimit),
-		rb:          rb,
-		stats:       stats,
-		done:        make(chan struct{}),
-		userAgent:   userAgent,
+		// Default bodySem to the full pipeline depth (no separate BODY bound);
+		// runConnSlot overrides this to Provider.Inflight when a deeper STAT
+		// pipeline is configured. Standalone connections keep them equal.
+		bodySem:   make(chan struct{}, inflightLimit),
+		rb:        rb,
+		stats:     stats,
+		done:      make(chan struct{}),
+		userAgent: userAgent,
 	}
 
 	// Server greeting is sent immediately upon connect.
@@ -363,6 +379,19 @@ func keepaliveExpectedCode(cmd string) int {
 	default:
 		return 111
 	}
+}
+
+// statCmdPrefix identifies STAT commands, the only bodyless request the pool
+// issues through the normal write path (keepalive DATE has its own path). STAT
+// has a single-line reply and no payload, so it may pipeline to the deeper
+// StatInflight depth without acquiring a bodySem slot.
+var statCmdPrefix = []byte("STAT ")
+
+// isCheapCommand reports whether payload is a bodyless command that should
+// bypass the BODY concurrency bound (bodySem) and pipeline to the full
+// inflightSem (StatInflight) depth.
+func isCheapCommand(payload []byte) bool {
+	return bytes.HasPrefix(payload, statCmdPrefix)
 }
 
 func failRequest(ch chan Response, err error) {
@@ -551,7 +580,7 @@ func (g *connGate) snapshot() (maxSlots, running int) {
 
 // runConnSlot is the slot goroutine that manages the lifecycle of a single
 // connection: IDLE → CONNECTING → ACTIVE → (death/idle) → IDLE.
-func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Request, hotReqCh <-chan *Request, hotPrioCh <-chan *Request, factory ConnFactory, inflight int, auth Auth, userAgent string, idleTimeout time.Duration, stallTimeout time.Duration, keepaliveInterval time.Duration, keepaliveCommand string, gate *connGate, stats *providerStats, providerName string, wg *sync.WaitGroup) {
+func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Request, hotReqCh <-chan *Request, hotPrioCh <-chan *Request, factory ConnFactory, inflight int, statInflight int, auth Auth, userAgent string, idleTimeout time.Duration, stallTimeout time.Duration, keepaliveInterval time.Duration, keepaliveCommand string, gate *connGate, stats *providerStats, providerName string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	// Shared read buffer persists across reconnections to avoid re-growing.
@@ -611,7 +640,10 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 			continue
 		}
 
-		nc, err := newNNTPConnectionFromConn(ctx, conn, inflight, reqCh, prioCh, auth, userAgent, &sharedBuf, stats)
+		// Size the pipeline (inflightSem/pending) to statInflight so bodyless
+		// STAT commands can pipeline deep; bodySem is overridden below to the
+		// (smaller) Inflight so concurrent bodies stay bounded.
+		nc, err := newNNTPConnectionFromConn(ctx, conn, statInflight, reqCh, prioCh, auth, userAgent, &sharedBuf, stats)
 		if err != nil {
 			_ = conn.Close()
 			failRequest(firstReq.RespCh, fmt.Errorf("%s: %w", providerName, err))
@@ -637,6 +669,10 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 		}
 
 		// ACTIVE: run the connection with the bootstrap request.
+		// Bound concurrent bodies to Inflight while the pipeline (inflightSem)
+		// allows STAT to reach statInflight. When statInflight == inflight this
+		// is identical to the default (both caps equal).
+		nc.bodySem = make(chan struct{}, inflight)
 		nc.firstReq = firstReq
 		nc.idleTimeout = idleTimeout
 		nc.stallTimeout = stallTimeout
@@ -730,6 +766,24 @@ func (c *NNTPConnection) Run() {
 		case <-c.ctx.Done():
 			failRequest(req.RespCh, c.ctx.Err())
 			return
+		}
+
+		// Body-bearing requests additionally take a bodySem slot so concurrent
+		// bodies stay bounded by Inflight even when the pipeline (inflightSem)
+		// is deeper for STAT. Bodyless STAT skips this and pipelines deep.
+		if !isCheapCommand(req.Payload) {
+			select {
+			case c.bodySem <- struct{}{}:
+				req.heldBody = true
+			case <-req.Ctx.Done():
+				<-c.inflightSem
+				failRequest(req.RespCh, req.Ctx.Err())
+				goto mainLoop // connection still good
+			case <-c.ctx.Done():
+				<-c.inflightSem
+				failRequest(req.RespCh, c.ctx.Err())
+				return
+			}
 		}
 
 		dl, hasDL := req.writeDeadline()
@@ -955,6 +1009,23 @@ mainLoop:
 			failRequest(req.RespCh, req.Ctx.Err())
 			continue
 		default:
+		}
+
+		// Body-bearing requests additionally take a bodySem slot so concurrent
+		// bodies stay bounded by Inflight even when the pipeline (inflightSem)
+		// is deeper for STAT. Bodyless STAT skips this and pipelines deep.
+		if !isCheapCommand(req.Payload) {
+			select {
+			case c.bodySem <- struct{}{}:
+				req.heldBody = true
+			case <-req.Ctx.Done():
+				<-c.inflightSem
+				failRequest(req.RespCh, req.Ctx.Err())
+				continue
+			case <-c.ctx.Done():
+				<-c.inflightSem
+				return
+			}
 		}
 
 		// per-request write deadline (cached to avoid redundant syscalls)
@@ -1198,8 +1269,11 @@ func (c *NNTPConnection) readerLoop() {
 		}
 		safeClose(req.RespCh)
 
-		// release inflight slot
+		// release inflight slot (and the body slot, if this request took one)
 		<-c.inflightSem
+		if req.heldBody {
+			<-c.bodySem
+		}
 
 		// If we hit a timeout, cancellation-related network error, or protocol
 		// desync, close the connection so the pool replaces it with a fresh one.
@@ -1290,7 +1364,8 @@ type Provider struct {
 	TLSConfig       *tls.Config
 	Auth            Auth
 	Connections     int
-	Inflight        int           // 0 defaults to 1
+	Inflight        int           // 0 defaults to 1; max concurrent BODY (and other body-bearing) commands per connection
+	StatInflight    int           // 0 defaults to Inflight; deeper pipeline depth for bodyless STAT commands. Because STAT carries no payload, many can be in flight per connection at negligible memory cost, amortising round-trips. Set higher than Inflight (e.g. 50-100) for STAT-heavy workloads without inflating BODY memory.
 	Factory         ConnFactory   // overrides Host/TLSConfig when set
 	Backup          bool          // if true, only used when main providers return 430
 	SkipPing        bool          // if true, skip the DATE ping on startup (for providers that don't support DATE)
@@ -1537,6 +1612,13 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 	if inflight <= 0 {
 		inflight = 1
 	}
+	// STAT (bodyless) may pipeline deeper than BODY. The overall pipeline cap is
+	// max(Inflight, StatInflight); 0 or a smaller value means "same as Inflight"
+	// (no separate STAT lane — fully backward compatible).
+	statInflight := p.StatInflight
+	if statInflight < inflight {
+		statInflight = inflight
+	}
 
 	factory := p.Factory
 	if factory == nil {
@@ -1619,7 +1701,7 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 
 	for range p.Connections {
 		c.wg.Add(1)
-		go runConnSlot(gctx, g.reqCh, g.prioCh, g.hotReqCh, g.hotPrioCh, factory, inflight, p.Auth, p.UserAgent, p.IdleTimeout, stall, kaInterval, kaCmd, gate, &g.stats, name, &c.wg)
+		go runConnSlot(gctx, g.reqCh, g.prioCh, g.hotReqCh, g.hotPrioCh, factory, inflight, statInflight, p.Auth, p.UserAgent, p.IdleTimeout, stall, kaInterval, kaCmd, gate, &g.stats, name, &c.wg)
 	}
 
 	return g

--- a/stat.go
+++ b/stat.go
@@ -1,0 +1,148 @@
+package nntppool
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// defaultStatConcurrency bounds in-flight STATs when StatManyOptions.Concurrency
+// is unset. STAT is a single-line request with a single-line reply and no body,
+// so it is purely round-trip-latency bound; a high default lets the pool amortise
+// RTT by keeping many checks outstanding across all connections at once.
+const defaultStatConcurrency = 64
+
+// StatManyResult is the per-message outcome streamed by StatMany and StatAsync.
+// A genuine miss (article not found, NNTP 430/423) is reported as
+// Err == ErrArticleNotFound with a nil Result — it is a normal outcome of an
+// existence sweep, not a fatal error.
+type StatManyResult struct {
+	MessageID string
+	Result    *StatResult // non-nil on 2xx
+	Err       error
+}
+
+// StatManyOptions tunes a StatMany sweep.
+type StatManyOptions struct {
+	// Concurrency bounds the number of STATs outstanding across the whole pool
+	// at once. <= 0 uses defaultStatConcurrency.
+	Concurrency int
+
+	// Priority routes each STAT through the priority channel so idle connections
+	// pick it up ahead of normal (e.g. BODY) traffic.
+	Priority bool
+
+	// Provider, when set, restricts every STAT to the named provider group
+	// (per-provider availability audit — retention differs per provider). The
+	// name matches Client provider names ("host:port" or "host:port+username").
+	// When empty, STATs dispatch across the whole pool with the same
+	// cross-provider/backup failover semantics as Stat ("exists anywhere").
+	Provider string
+}
+
+// StatMany checks the existence of many articles concurrently, streaming a
+// StatManyResult per message-id as each check completes (results arrive out of
+// order). The returned channel is closed once every dispatched check has
+// reported. If ctx is cancelled mid-sweep, dispatch stops, in-flight checks are
+// cancelled, and the channel is closed; message-ids not yet dispatched produce
+// no result, so callers should check ctx.Err() after draining.
+func (c *Client) StatMany(ctx context.Context, messageIDs []string, opts StatManyOptions) <-chan StatManyResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	conc := opts.Concurrency
+	if conc <= 0 {
+		conc = defaultStatConcurrency
+	}
+	if conc > len(messageIDs) && len(messageIDs) > 0 {
+		conc = len(messageIDs)
+	}
+
+	out := make(chan StatManyResult, conc)
+
+	// Resolve the target group once (outside the goroutine) so an unknown
+	// provider name fails every id with a clear error rather than silently
+	// dispatching pool-wide.
+	var target *providerGroup
+	var targetErr error
+	if opts.Provider != "" {
+		if target = c.findGroup(opts.Provider); target == nil {
+			targetErr = fmt.Errorf("nntp: provider %q not found", opts.Provider)
+		}
+	}
+
+	go func() {
+		defer close(out)
+
+		sem := make(chan struct{}, conc)
+		var wg sync.WaitGroup
+
+	dispatch:
+		for _, id := range messageIDs {
+			select {
+			case <-ctx.Done():
+				break dispatch
+			case sem <- struct{}{}:
+			}
+
+			wg.Add(1)
+			go func(id string) {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				res := c.statOne(ctx, id, target, targetErr, opts.Priority)
+				select {
+				case out <- res:
+				case <-ctx.Done():
+				}
+			}(id)
+		}
+
+		wg.Wait()
+	}()
+
+	return out
+}
+
+// statOne performs a single STAT and maps it to a StatManyResult. When target is
+// set the check is confined to that provider group; otherwise it uses the
+// pool-wide failover path (Send/SendPriority).
+func (c *Client) statOne(ctx context.Context, messageID string, target *providerGroup, targetErr error, priority bool) StatManyResult {
+	if targetErr != nil {
+		return StatManyResult{MessageID: messageID, Err: targetErr}
+	}
+
+	payload := statPayload(messageID)
+
+	var resp Response
+	switch {
+	case target != nil:
+		resp = c.statViaGroup(ctx, target, payload, priority)
+	case priority:
+		resp = <-c.SendPriority(ctx, payload, nil)
+	default:
+		resp = <-c.Send(ctx, payload, nil)
+	}
+
+	result, err := parseStat(messageID, resp)
+	return StatManyResult{MessageID: messageID, Result: result, Err: err}
+}
+
+// statViaGroup issues a STAT against a single provider group, reusing the same
+// resilient single-group send (with fresh-connection retry on connection death)
+// that the failover path uses per provider. No cross-provider failover.
+func (c *Client) statViaGroup(ctx context.Context, g *providerGroup, payload []byte, priority bool) Response {
+	resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, nil, nil, priority)
+	switch {
+	case cancelled:
+		err := ctx.Err()
+		if err == nil {
+			err = c.ctx.Err()
+		}
+		return Response{Err: err}
+	case !ok:
+		return Response{Err: ErrConnectionDied}
+	default:
+		return resp
+	}
+}

--- a/stat_pipeline_test.go
+++ b/stat_pipeline_test.go
@@ -1,0 +1,281 @@
+package nntppool
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestStatInflight_DeepPipeline verifies that with StatInflight > Inflight,
+// bodyless STAT commands pipeline deeper than Inflight. The mock server withholds
+// every reply until it has *received* `hold` commands; if the pipeline were
+// capped at Inflight (2) the client could never get `hold` (8) STATs onto the
+// wire and the sweep would deadlock (caught by the timeout).
+func TestStatInflight_DeepPipeline(t *testing.T) {
+	const hold = 8
+	var maxDepth int32
+
+	factory := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 server ready\r\n"))
+			buf := make([]byte, 8192)
+			received := 0
+			flushed := false
+			var pending [][]byte
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				for _, line := range strings.Split(string(buf[:n]), "\r\n") {
+					if line == "" {
+						continue
+					}
+					received++
+					pending = append(pending, []byte("223 0 <x@h> exists\r\n"))
+				}
+				if !flushed && received >= hold {
+					atomic.StoreInt32(&maxDepth, int32(received))
+					flushed = true
+				}
+				if flushed {
+					for _, r := range pending {
+						_, _ = server.Write(r)
+					}
+					pending = nil
+				}
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:      factory,
+		Connections:  1,
+		Inflight:     2,
+		StatInflight: 16,
+		SkipPing:     true,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ids := make([]string, 32)
+	for i := range ids {
+		ids[i] = "x@h"
+	}
+
+	done := make(chan int, 1)
+	go func() {
+		n := 0
+		for r := range c.StatMany(context.Background(), ids, StatManyOptions{Concurrency: 32}) {
+			if r.Err == nil && r.Result != nil {
+				n++
+			}
+		}
+		done <- n
+	}()
+
+	select {
+	case n := <-done:
+		if n != len(ids) {
+			t.Fatalf("got %d successful STATs, want %d", n, len(ids))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("StatMany timed out — STAT pipeline appears capped at Inflight, not StatInflight")
+	}
+
+	if d := atomic.LoadInt32(&maxDepth); d < hold {
+		t.Errorf("max STAT pipeline depth = %d, want >= %d (Inflight=2, StatInflight=16)", d, hold)
+	}
+}
+
+// TestStatInflight_BodyBounded verifies that raising StatInflight does NOT raise
+// BODY concurrency: even with StatInflight=16, concurrent BODY commands stay
+// bounded by Inflight (2). The server holds body replies until the test releases
+// them, recording the peak number of concurrently-outstanding bodies.
+func TestStatInflight_BodyBounded(t *testing.T) {
+	const nBodies = 6
+	const wantMax = 2 // == Inflight
+
+	var cur, max int32
+	release := make(chan struct{})
+	reachedCap := make(chan struct{})
+	var capOnce sync.Once
+	var wmu sync.Mutex
+
+	factory := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			wmu.Lock()
+			_, _ = server.Write([]byte("200 server ready\r\n"))
+			wmu.Unlock()
+			buf := make([]byte, 8192)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				for _, line := range strings.Split(string(buf[:n]), "\r\n") {
+					if line == "" {
+						continue
+					}
+					go func() {
+						v := atomic.AddInt32(&cur, 1)
+						for {
+							m := atomic.LoadInt32(&max)
+							if v <= m || atomic.CompareAndSwapInt32(&max, m, v) {
+								break
+							}
+						}
+						if v >= wantMax {
+							capOnce.Do(func() { close(reachedCap) })
+						}
+						<-release
+						atomic.AddInt32(&cur, -1)
+						wmu.Lock()
+						_, _ = server.Write([]byte("222 0 <x@h> body follows\r\n.\r\n"))
+						wmu.Unlock()
+					}()
+				}
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:      factory,
+		Connections:  1,
+		Inflight:     2,
+		StatInflight: 16,
+		SkipPing:     true,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	var wg sync.WaitGroup
+	for range nBodies {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.Body(context.Background(), "x@h")
+		}()
+	}
+
+	select {
+	case <-reachedCap:
+	case <-time.After(3 * time.Second):
+		t.Fatal("bodies never reached expected concurrency")
+	}
+	close(release)
+
+	waitDone := make(chan struct{})
+	go func() { wg.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Body calls did not all complete")
+	}
+
+	if m := atomic.LoadInt32(&max); m != wantMax {
+		t.Errorf("peak concurrent bodies = %d, want %d (Inflight); StatInflight must not loosen the BODY bound", m, wantMax)
+	}
+}
+
+// TestStatInflight_NoSemaphoreLeak interleaves STAT, BODY, cancelled, and 430
+// requests through a client with a separate STAT lane, then confirms the pool
+// stays healthy — a leaked inflightSem/bodySem slot would eventually stall the
+// pipeline and hang the final sentinel STAT.
+func TestStatInflight_NoSemaphoreLeak(t *testing.T) {
+	factory := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 server ready\r\n"))
+			buf := make([]byte, 8192)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				for _, line := range strings.Split(string(buf[:n]), "\r\n") {
+					if line == "" {
+						continue
+					}
+					switch {
+					case strings.HasPrefix(line, "STAT <miss"):
+						_, _ = server.Write([]byte("430 no such article\r\n"))
+					case strings.HasPrefix(line, "STAT "):
+						_, _ = server.Write([]byte("223 0 <x@h> exists\r\n"))
+					case strings.HasPrefix(line, "BODY "):
+						_, _ = server.Write([]byte("222 0 <x@h> body follows\r\n.\r\n"))
+					default:
+						_, _ = server.Write([]byte("500 unknown\r\n"))
+					}
+				}
+			}
+		}()
+		return client, nil
+	}
+
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:      factory,
+		Connections:  2,
+		Inflight:     2,
+		StatInflight: 8,
+		SkipPing:     true,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	var wg sync.WaitGroup
+	launch := func(fn func()) {
+		wg.Add(1)
+		go func() { defer wg.Done(); fn() }()
+	}
+
+	for i := range 80 {
+		switch i % 4 {
+		case 0:
+			launch(func() { _, _ = c.Stat(context.Background(), "x@h") })
+		case 1:
+			launch(func() { _, _ = c.Body(context.Background(), "x@h") })
+		case 2:
+			launch(func() { _, _ = c.Stat(context.Background(), "miss@h") })
+		case 3:
+			launch(func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel() // pre-cancelled: exercises the cancel-before-send release path
+				_, _ = c.Body(ctx, "x@h")
+			})
+		}
+	}
+
+	waitDone := make(chan struct{})
+	go func() { wg.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("mixed workload stalled — likely a semaphore leak")
+	}
+
+	// Sentinel: if any slot leaked, the pipeline would be permanently narrowed
+	// and this would hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := c.Stat(ctx, "x@h"); err != nil {
+		t.Fatalf("sentinel STAT failed after mixed workload: %v", err)
+	}
+}

--- a/stat_test.go
+++ b/stat_test.go
@@ -1,0 +1,294 @@
+package nntppool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// makeStatByIDFactory returns a ConnFactory whose mock server answers STAT
+// commands based on message-id. replies maps a bare message-id to the status
+// line to return; ids absent from the map get a 430. Every received command
+// (except DATE pings) is appended to cmdLog under mu.
+func makeStatByIDFactory(t *testing.T, mu *sync.Mutex, cmdLog *[]string, replies map[string]string) ConnFactory {
+	t.Helper()
+	return func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 server ready\r\n"))
+			buf := make([]byte, 4096)
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				cmd := strings.TrimRight(string(buf[:n]), "\r\n")
+				if strings.HasPrefix(cmd, "DATE") {
+					_, _ = server.Write([]byte("111 20240101000000\r\n"))
+					continue
+				}
+				if mu != nil {
+					mu.Lock()
+					*cmdLog = append(*cmdLog, cmd)
+					mu.Unlock()
+				}
+				reply := "430 no such article"
+				if strings.HasPrefix(cmd, "STAT ") {
+					id := strings.Trim(strings.TrimPrefix(cmd, "STAT "), "<>")
+					if r, ok := replies[id]; ok {
+						reply = r
+					}
+				}
+				_, _ = fmt.Fprintf(server, "%s\r\n", reply)
+			}
+		}()
+		return client, nil
+	}
+}
+
+// collectStat drains a StatMany/StatAsync channel into a map keyed by message-id.
+func collectStat(ch <-chan StatManyResult) map[string]StatManyResult {
+	m := make(map[string]StatManyResult)
+	for r := range ch {
+		m[r.MessageID] = r
+	}
+	return m
+}
+
+func TestStatMany_AllExist(t *testing.T) {
+	ids := []string{"a@h", "b@h", "c@h"}
+	replies := map[string]string{
+		"a@h": "223 1 <a@h> exists",
+		"b@h": "223 2 <b@h> exists",
+		"c@h": "223 3 <c@h> exists",
+	}
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:     makeStatByIDFactory(t, nil, nil, replies),
+		Connections: 3,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	got := collectStat(c.StatMany(context.Background(), ids, StatManyOptions{}))
+	if len(got) != len(ids) {
+		t.Fatalf("got %d results, want %d", len(got), len(ids))
+	}
+	for _, id := range ids {
+		r, ok := got[id]
+		if !ok {
+			t.Fatalf("missing result for %s", id)
+		}
+		if r.Err != nil {
+			t.Errorf("%s: unexpected err %v", id, r.Err)
+		}
+		if r.Result == nil {
+			t.Fatalf("%s: nil result", id)
+		}
+		if r.Result.MessageID != id {
+			t.Errorf("%s: MessageID = %q", id, r.Result.MessageID)
+		}
+	}
+}
+
+func TestStatMany_MissingIsNonFatal(t *testing.T) {
+	ids := []string{"hit@h", "miss@h"}
+	replies := map[string]string{
+		"hit@h": "223 1 <hit@h> exists",
+		// miss@h absent => 430
+	}
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:     makeStatByIDFactory(t, nil, nil, replies),
+		Connections: 2,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	got := collectStat(c.StatMany(context.Background(), ids, StatManyOptions{}))
+	if len(got) != 2 {
+		t.Fatalf("got %d results, want 2", len(got))
+	}
+	if r := got["hit@h"]; r.Err != nil || r.Result == nil {
+		t.Errorf("hit: err=%v result=%v", r.Err, r.Result)
+	}
+	miss := got["miss@h"]
+	if !errors.Is(miss.Err, ErrArticleNotFound) {
+		t.Errorf("miss: err = %v, want ErrArticleNotFound", miss.Err)
+	}
+	if miss.Result != nil {
+		t.Errorf("miss: result = %v, want nil", miss.Result)
+	}
+}
+
+func TestStatMany_Completeness(t *testing.T) {
+	const total = 200
+	ids := make([]string, total)
+	replies := make(map[string]string, total)
+	for i := range ids {
+		id := fmt.Sprintf("seg%d@h", i)
+		ids[i] = id
+		replies[id] = fmt.Sprintf("223 %d <%s> exists", i, id)
+	}
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:     makeStatByIDFactory(t, nil, nil, replies),
+		Connections: 8,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	got := collectStat(c.StatMany(context.Background(), ids, StatManyOptions{Concurrency: 16}))
+	if len(got) != total {
+		t.Fatalf("got %d unique results, want %d", len(got), total)
+	}
+	for _, id := range ids {
+		if r, ok := got[id]; !ok || r.Result == nil {
+			t.Fatalf("bad/missing result for %s: %+v", id, r)
+		}
+	}
+}
+
+func TestStatMany_ContextCancel(t *testing.T) {
+	const total = 500
+	ids := make([]string, total)
+	replies := make(map[string]string, total)
+	for i := range ids {
+		id := fmt.Sprintf("seg%d@h", i)
+		ids[i] = id
+		replies[id] = fmt.Sprintf("223 %d <%s> exists", i, id)
+	}
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:     makeStatByIDFactory(t, nil, nil, replies),
+		Connections: 4,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := c.StatMany(ctx, ids, StatManyOptions{Concurrency: 4})
+	// Read a few then cancel.
+	count := 0
+	for range ch {
+		count++
+		if count == 5 {
+			cancel()
+		}
+	}
+	// Channel must close (loop exits) without panic/deadlock. We don't assert an
+	// exact count — cancellation is racy — only that it terminates.
+	if count == 0 {
+		t.Fatal("expected at least some results before cancel")
+	}
+}
+
+func TestStatMany_ProviderTargeting(t *testing.T) {
+	var mu1, mu2 sync.Mutex
+	var p1Cmds, p2Cmds []string
+	replies := map[string]string{"x@h": "223 1 <x@h> exists"}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{
+			Host:        "provider-one:119",
+			Factory:     makeStatByIDFactory(t, &mu1, &p1Cmds, replies),
+			Connections: 2,
+		},
+		{
+			Host:        "provider-two:119",
+			Factory:     makeStatByIDFactory(t, &mu2, &p2Cmds, replies),
+			Connections: 2,
+		},
+	}, WithStatProbe(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	got := collectStat(c.StatMany(context.Background(),
+		[]string{"x@h"}, StatManyOptions{Provider: "provider-two:119"}))
+	if r := got["x@h"]; r.Err != nil || r.Result == nil {
+		t.Fatalf("x@h: err=%v result=%v", r.Err, r.Result)
+	}
+
+	mu1.Lock()
+	defer mu1.Unlock()
+	mu2.Lock()
+	defer mu2.Unlock()
+	if len(p1Cmds) != 0 {
+		t.Errorf("provider-one received %v, want none (targeted provider-two)", p1Cmds)
+	}
+	if len(p2Cmds) == 0 {
+		t.Errorf("provider-two received no STAT commands")
+	}
+}
+
+func TestStatMany_UnknownProvider(t *testing.T) {
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:     makeStatByIDFactory(t, nil, nil, map[string]string{"a@h": "223 1 <a@h> exists"}),
+		Connections: 1,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	got := collectStat(c.StatMany(context.Background(),
+		[]string{"a@h"}, StatManyOptions{Provider: "does-not-exist"}))
+	if r := got["a@h"]; r.Err == nil {
+		t.Errorf("want error for unknown provider, got result %v", r.Result)
+	}
+}
+
+func TestStatPriority(t *testing.T) {
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:     makeStatByIDFactory(t, nil, nil, map[string]string{"p@h": "223 7 <p@h> exists"}),
+		Connections: 1,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	res, err := c.StatPriority(context.Background(), "p@h")
+	if err != nil {
+		t.Fatalf("StatPriority: %v", err)
+	}
+	if res.Number != 7 || res.MessageID != "p@h" {
+		t.Errorf("got %+v, want Number=7 MessageID=p@h", res)
+	}
+}
+
+func TestStatAsync(t *testing.T) {
+	c, err := NewClient(context.Background(), []Provider{{
+		Factory:     makeStatByIDFactory(t, nil, nil, map[string]string{"async@h": "223 9 <async@h> exists"}),
+		Connections: 1,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	select {
+	case r := <-c.StatAsync(context.Background(), "async@h"):
+		if r.Err != nil {
+			t.Fatalf("StatAsync err: %v", r.Err)
+		}
+		if r.Result == nil || r.Result.Number != 9 {
+			t.Errorf("got %+v, want Number=9", r.Result)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("StatAsync timed out")
+	}
+}


### PR DESCRIPTION
## Summary

Speeds up STAT (article existence checking) — the backbone of NZB health checks and cross-provider availability lookups — on the two axes usenet cares about: fan-out across connections and per-connection pipelining. STAT is a single-line request with a single-line reply and no payload, so it is purely round-trip-latency bound and can be pipelined far more aggressively than BODY.

## What's included

**1. StatMany — streaming bulk API** (new stat.go)
- Fans a slice of message-IDs across the whole pool with bounded concurrency, streaming a StatManyResult per ID as each completes (out of order), closing the channel when done.
- A genuine miss (430/423) is reported as ErrArticleNotFound with a nil Result — a normal sweep outcome, not a fatal error.
- Options: Concurrency (default 64), Priority, and Provider (restrict to one provider group for per-provider availability audits). Cancelling ctx mid-sweep stops dispatch and cancels in-flight checks.

**2. StatPriority + StatAsync** (client.go)
- Mirror BodyPriority/BodyAsync. Extracted parseStat/statPayload helpers and refactored Stat onto them.

**3. Deep STAT pipeline lane — Provider.StatInflight** (nntp.go)
- Operators keep Inflight modest (5–10) to bound BODY memory. StatInflight lets bodyless STAT pipeline much deeper (e.g. 50–100) within the same client.
- A new per-connection bodySem (cap = Inflight) bounds concurrent bodies; inflightSem/pending are sized to StatInflight so STAT pipelines deep while BODY concurrency is unchanged. Cheapness is auto-detected from the STAT payload prefix, so plain Stat, StatMany, and the internal 430 probe all benefit — no new API.
- StatInflight=0 defaults to Inflight and is byte-for-byte backward compatible.
- Caveat (documented): replies are read FIFO per connection, so a STAT queued behind an in-progress BODY on the same connection waits; a pure STAT sweep reaches full depth.

## Test plan
- New stat_test.go: StatMany all-exist, miss-is-non-fatal, completeness (exactly-once), context cancel, provider targeting, unknown provider; StatPriority; StatAsync.
- New stat_pipeline_test.go: STAT pipelines past Inflight (depth >= 8 with Inflight=2/StatInflight=16); BODY stays bounded to Inflight even at StatInflight=16; no semaphore leak under 80 interleaved STAT/BODY/cancelled/430 ops + sentinel.
- Full suite green under 'go test -race ./...' and '-count=10'; golangci-lint 0 issues; existing tests unchanged (backward compatible).

## Docs
- README: documented StatMany/StatPriority/StatAsync, a bulk existence-check example, StatManyOptions, the StatInflight field, and a 'Tuning STAT throughput' section.