### PR TITLE
Fix transport outcomes, validation, and ordered fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,15 @@ A high-performance NNTP connection pool library for Go. It manages multiple NNTP
 - **Multi-provider pooling**: configure N connection slots per provider; supports both main and backup tiers
 - **Command pipelining**: configurable inflight requests per connection (default: 1)
 - **Weighted round-robin dispatch**: distributes load by available inflight capacity; FIFO mode also available
-- **Automatic failover**: on 430 (article not found) the pool retries every main provider before falling back to backups
-- **Same-host deduplication**: a 430 from one account on a host skips all other accounts on the same host
+- **Automatic failover**: ordered fallback for hard absence (423/430), temporary failure, corruption, unavailability, and transport failure, followed by failure-only backups
+- **Same-host deduplication**: a hard-absence response from one account on a host skips all other accounts on the same host
 - **Provider removal on 502**: permanently unavailable providers are atomically removed from the pool
 - **Auto-reconnect after 502**: optionally re-add a provider after a configurable delay (`ReconnectDelay`)
-- **yEnc decoding**: SIMD-accelerated via `rapidyenc`, with CRC32 validation and `=ybegin`/`=ypart`/`=yend` metadata
+- **Validated yEnc decoding**: SIMD-accelerated via `rapidyenc`, with complete framing, size, part, decoder, and supplied-CRC validation
 - **UU encoding support**: detection and decoding of UUEncoded articles
 - **Streaming delivery**: decode directly to an `io.Writer` without memory buffering
-- **Priority channel**: urgent requests preempt the normal queue on already-connected connections
+- **Strict unsent priority**: urgent requests precede normal queued work; commands already written to an NNTP pipeline remain FIFO
+- **Attempt evidence**: successful results and structured errors expose stable provider IDs, typed outcomes, validation status, and separated queue/head/service durations
 - **Idle timeout**: automatically disconnect and clean up connections that have been idle too long
 - **Application-level keepalive**: configurable lightweight NNTP probes to detect zombie connections
 - **Dynamic provider management**: add or remove providers at runtime without restarting the client
@@ -158,7 +159,8 @@ func main() {
 
 ### Multiple providers with backup
 
-Main providers are tried using round-robin (or FIFO). If all main providers return 430 (article not found), the pool falls back to backup providers.
+Main providers are tried using round-robin (or FIFO). Backups are failure-only:
+they are contacted after all eligible mains fail to return a usable result.
 
 ```go
 providers := []nntppool.Provider{
@@ -177,7 +179,7 @@ providers := []nntppool.Provider{
         Inflight:    2,
     },
     {
-        // Backup: only contacted when all main providers return 430
+        // Backup: contacted only after all eligible main providers fail
         Host:        "news.backup-provider.com:119",
         Auth:        nntppool.Auth{Username: "b1", Password: "bp1"},
         Connections: 10,
@@ -261,7 +263,9 @@ for i, ch := range channels {
 
 ### Priority requests
 
-`BodyPriority` and `SendPriority` enqueue on a separate priority channel. Idle connections prefer priority requests over normal ones, reducing latency for time-sensitive fetches.
+`BodyPriority` and `SendPriority` enqueue on a separate priority channel. Unsent
+priority work is selected before normal queued work. NNTP replies are wire-order
+FIFO, so a command that was already written cannot be preempted.
 
 ```go
 // Fetch the most important segment first
@@ -606,7 +610,9 @@ client.Send()
     → try hotReqCh (non-blocking) — succeeds only if a connection is already idle with inflight capacity
     → fall back to reqCh (wakes a cold slot or queues behind in-flight requests)
     → receive response from innerCh
-    → on 430: retry next provider, track host to skip duplicates
+    → on 423/430: retry next provider, track host to skip duplicates
+    → on 451: retry once on a fresh connection, then advance
+    → on buffered BODY corruption: retire the socket and advance
     → on 502: remove provider, retry
     → on all exhausted: deliver last response or error
 ```
@@ -622,7 +628,7 @@ Both strategies skip quota-exceeded providers during normal dispatch. If all pro
 ### Failover and retry logic
 
 ```
-1. Attempt all main providers (round-robin start, then sequentially):
+1. Attempt all main providers (round-robin start, then configured order):
    - 2xx → success, return response immediately
    - 430/423 → article not found on this provider:
        • record host in skipHosts (up to 4)
@@ -632,16 +638,18 @@ Both strategies skip quota-exceeded providers during normal dispatch. If all pro
        • atomically remove provider from pool
        • if ReconnectDelay > 0: schedule re-add after delay
        • try next provider
+   - 451 → retry once on a fresh connection after short jitter, then try next provider
+   - buffered BODY framing/decode/size/CRC failure → retire the socket, try next provider
    - connection error → try next provider
    - quota exceeded → skip, try next provider
 
-2. If all mains returned 430: attempt backup providers in order
-   - backup 430 → still deliver (no further retry)
+2. If all mains failed: attempt failure-only backup providers in order
+   - backup 423/430 → continue through remaining backups
    - backup 502 → remove, try next backup
 
 3. If all providers exhausted:
-   - if any 430 was received → return that 430 response
-   - else → return last error or "all providers exhausted"
+   - return hard absence only when every eligible provider conclusively reported 423/430
+   - mixed outcome classes return a structured inconclusive error with per-attempt evidence
 ```
 
 ### Read buffer internals
@@ -667,7 +675,8 @@ The `NNTPResponse` type in `reader.go` implements `streamFeeder` and processes r
    - Delegates to `rapidyenc.DecodeIncremental()` for SIMD-accelerated in-place decoding
    - Accumulates CRC32 using `crc32.Update()` on each decoded chunk
    - Parses `=yend` for `pcrc32=` or `crc32=` field
-   - Returns `ErrCRCMismatch` alongside the body when CRCs differ
+   - Before buffered acceptance, requires coherent `=ybegin`/`=ypart`/`=yend`, decoded sizes, native decoder success, and every supplied CRC (including `00000000`)
+   - A failed buffered attempt is discarded and may fall back; a caller-owned writer is never restarted after receiving decoded bytes
 4. **UU path**: detected but not decoded further (format is noted in `ArticleBody.Encoding`)
 5. **NNTP terminator**: `.\r\n` detected by `rapidyenc.DecodeIncremental` returning `EndArticle`; backs up 3 bytes to include the terminator in subsequent header parsing
 
@@ -716,7 +725,7 @@ Validates all providers, pings each (unless `SkipPing` is set), and starts conne
 - all providers are `Backup: true` (at least one non-backup required)
 - any provider has `Connections <= 0`
 - any provider has neither `Host` nor `Factory`
-- two providers resolve to the same name
+- two providers resolve to the same name or stable `ID`
 
 Provider names default to `host:port` or `host:port+username` (when auth is set). Factory-based providers without `Host` are named `provider-N`.
 
@@ -728,13 +737,16 @@ Provider names default to `host:port` or `host:port+username` (when auth is set)
 | `BodyStream` | `(ctx, messageID, w, onMeta...) (*ArticleBody, error)` | Decode and stream to `io.Writer`; `body.Bytes` is nil |
 | `BodyAsync` | `(ctx, messageID, w, onMeta...) <-chan BodyResult` | Non-blocking fan-out; returns channel receiving exactly one `BodyResult` |
 | `BodyPriority` | `(ctx, messageID, onMeta...) (*ArticleBody, error)` | Like `Body` but dispatched via the priority queue |
+| `BodyTargeted` | `(ctx, messageID, TargetedBodyOptions, onMeta...) (*ArticleBody, error)` | Validated BODY from exactly one provider, optionally requiring a fresh transport |
 | `Head` | `(ctx, messageID) (*ArticleHead, error)` | Fetch RFC 5322 headers; returns parsed `map[string][]string` with folding resolved |
 | `Stat` | `(ctx, messageID) (*StatResult, error)` | Check article existence without transferring body |
 | `StatPriority` | `(ctx, messageID) (*StatResult, error)` | Like `Stat` but dispatched via the priority queue |
 | `StatAsync` | `(ctx, messageID) <-chan StatManyResult` | Non-blocking single existence check; channel receives exactly one result |
 | `StatMany` | `(ctx, messageIDs, StatManyOptions) <-chan StatManyResult` | Concurrent bulk existence check; streams one result per ID as it completes |
 
-The `onMeta` optional callback is called once `=ybegin`/`=ypart` is fully parsed (before any body bytes), enabling pre-allocation or filename routing.
+The `onMeta` optional callback is called once `=ybegin`/`=ypart` is parsed,
+before final decoding and integrity validation. Its data is provisional and must
+not be treated as provider availability or integrity evidence.
 
 ### Posting articles
 
@@ -751,7 +763,7 @@ func (c *Client) Send(ctx context.Context, payload []byte, bodyWriter io.Writer,
 func (c *Client) SendPriority(ctx context.Context, payload []byte, bodyWriter io.Writer, onMeta ...func(YEncMeta)) <-chan Response
 ```
 
-Both return immediately with a buffered channel (capacity 1). The caller receives exactly one `Response`. Use `bodyWriter = nil` to buffer decoded bytes in `Response.Body`; use `io.Discard` to throw them away; use any `io.Writer` to stream them.
+Both return immediately with a buffered channel (capacity 1). The caller receives exactly one `Response`. Use `bodyWriter = nil` to buffer decoded bytes in `Response.Body`; use `io.Discard` to throw them away; use any `io.Writer` to stream them. Raw `Send` retains v4 behavior and does not enable the high-level BODY integrity contract; its BODY evidence reports `not_requested`.
 
 ### Provider management
 
@@ -761,7 +773,7 @@ func (c *Client) RemoveProvider(name string) error
 func (c *Client) NumProviders() int
 ```
 
-`AddProvider` validates, pings (unless `SkipPing`), starts connection slots, and atomically appends to main or backup groups. Returns an error on validation failure or duplicate name.
+`AddProvider` validates, pings (unless `SkipPing`), starts connection slots, and atomically appends to main or backup groups. Returns an error on validation failure or duplicate name/stable ID.
 
 `RemoveProvider` cancels the group's context (causing all slot goroutines to exit), stops the `connGate`, and atomically removes it from the pool. Goroutines wind down asynchronously; `Client.Close()` waits for all via a `sync.WaitGroup`.
 
@@ -787,6 +799,8 @@ Dials a temporary connection, authenticates, sends DATE, and returns RTT + serve
 // ArticleBody is the result of Body/BodyStream/BodyAsync.
 type ArticleBody struct {
     MessageID     string
+    ProviderID    string          // stable Provider.ID (or resolved-name fallback)
+    Attempts      []AttemptEvidence
     Bytes         []byte          // nil when BodyStream was used
     BytesDecoded  int             // decoded payload bytes
     BytesConsumed int             // wire bytes consumed (pre-decode)
@@ -794,7 +808,38 @@ type ArticleBody struct {
     YEnc          YEncMeta        // yEnc metadata (zero value for non-yEnc)
     CRC           uint32          // actual CRC of decoded bytes
     ExpectedCRC   uint32          // CRC from =yend (0 when absent)
-    CRCValid      bool            // true when ExpectedCRC != 0 && CRC == ExpectedCRC
+    CRCProvided   bool
+    CRCValid      bool            // true when a supplied CRC, including zero, matched
+}
+
+// AttemptEvidence contains bounded transport facts for one provider attempt.
+type AttemptEvidence struct {
+    ProviderID               string
+    Operation                Operation
+    Outcome                  OutcomeKind
+    ResponseCode             int
+    BodyValidation           BodyValidationStatus
+    Cause                    error
+    ProviderResponseTimeout  bool
+    PoolQueueDuration        time.Duration
+    PipelineHeadWaitDuration time.Duration
+    ResponseServiceDuration  time.Duration
+}
+
+// TransportError wraps the existing sentinel/protocol cause so errors.Is and
+// errors.As checks remain valid after provider exhaustion or cancellation.
+type TransportError struct {
+    Kind         OutcomeKind
+    ProviderID   string
+    ResponseCode int
+    Attempts     []AttemptEvidence
+    Cause        error
+}
+
+type TargetedBodyOptions struct {
+    Provider       string // stable ID or resolved provider name
+    FreshTransport bool
+    Priority       bool
 }
 
 // YEncMeta holds fields from =ybegin and =ypart headers.
@@ -818,8 +863,10 @@ type PostHeaders struct {
 
 // StatResult is the result of a STAT command.
 type StatResult struct {
-    MessageID string
-    Number    int64 // article number in current group (0 if no group selected)
+    MessageID  string
+    ProviderID string
+    Attempts   []AttemptEvidence
+    Number     int64 // article number in current group (0 if no group selected)
 }
 
 // ArticleHead holds the result of a HEAD command.
@@ -831,12 +878,18 @@ type ArticleHead struct {
 // ProviderStats is a snapshot of one provider's metrics.
 type ProviderStats struct {
     Name              string
+    ProviderID        string
     AvgSpeed          float64       // bytes/sec since client start
     BytesConsumed     int64         // raw wire bytes
     Missing           int64         // 430/423 responses
     Errors            int64         // network errors and bad status codes
     ActiveConnections int           // currently running connection slots
     MaxConnections    int           // configured Connections value
+    PipelineInUse     int
+    PipelineLimit     int
+    BackgroundStatInUse  int
+    BackgroundStatLimit  int
+    PriorityHeadroom     int
     Ping              PingResult    // result of startup DATE ping
     QuotaBytes        int64         // 0 = unlimited
     QuotaUsed         int64         // bytes consumed in current period
@@ -853,19 +906,26 @@ type ProviderStats struct {
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `ID` | `string` | resolved provider name | Stable transport identity returned in results, attempt evidence, and stats |
 | `Host` | `string` | — | Server address as `host:port`, e.g. `news.example.com:563` |
 | `TLSConfig` | `*tls.Config` | nil (plain TCP) | Pass a `tls.Config` to enable TLS; set `ServerName` for SNI |
 | `Auth` | `Auth` | — | `Username` and `Password` for AUTHINFO handshake |
 | `Connections` | `int` | — | **Required.** Number of connection slots for this provider |
 | `Inflight` | `int` | 1 | Max concurrent BODY (and other body-bearing) commands per connection |
 | `StatInflight` | `int` | 0 (= `Inflight`) | Pipeline depth for bodyless STAT commands; set higher than `Inflight` (e.g. 50–100) to amortise round-trips on existence sweeps without inflating BODY memory |
+| `BackgroundStatInflight` | `int` | 0 (= `StatInflight`) | Maximum unanswered ordinary, non-priority STAT commands per connection |
+| `PriorityHeadroom` | `int` | 0 | Pipeline slots per connection that ordinary STAT cannot consume |
 | `Factory` | `ConnFactory` | nil | Custom dialer `func(ctx) (net.Conn, error)`; overrides `Host`/`TLSConfig` |
-| `Backup` | `bool` | false | If true, only used when all main providers return 430 |
+| `Backup` | `bool` | false | If true, used only after all eligible main providers fail the request |
 | `SkipPing` | `bool` | false | Skip the startup DATE ping (for servers that don't support DATE) |
 | `IdleTimeout` | `time.Duration` | 0 (disabled) | Disconnect idle connections after this duration; 0 = never |
 | `ThrottleRestore` | `time.Duration` | 30s | How long to wait before restoring throttled slots after a 502/400 greeting |
 | `KeepAlive` | `time.Duration` | 30s | TCP keep-alive interval; negative disables OS-level keep-alive |
 | `ReconnectDelay` | `time.Duration` | 0 (disabled) | If set, re-adds the provider this long after a 502 removal |
+| `AttemptTimeout` | `time.Duration` | adaptive, 2s–10s | Time-to-first-response-byte bound starting only at FIFO response head; caller context owns pool and pipeline wait |
+| `StallTimeout` | `time.Duration` | 8s | Rolling body-progress timeout; negative disables it |
+| `AbandonedBodyDrainBytes` | `int` | 1 MiB | Maximum obsolete BODY bytes drained after cancellation before retiring the socket |
+| `AbandonedBodyDrainTimeout` | `time.Duration` | 250ms | Maximum obsolete BODY drain time before retiring the socket |
 | `KeepaliveInterval` | `time.Duration` | 0 (disabled) | Application-level probe interval; 0 or when `SkipPing && KeepaliveCommand == ""` disables |
 | `KeepaliveCommand` | `string` | `"DATE"` | NNTP command for application-level probe: `"DATE"` (111), `"HELP"` (100), `"CAPABILITIES"` (101) |
 | `UserAgent` | `string` | `""` | Sent as `X-User-Agent` or equivalent; empty disables |
@@ -899,7 +959,8 @@ nntppool.WithDispatchStrategy(nntppool.DispatchFIFO)
 | `ErrAuthRequired` | 480 | Authentication required before this command |
 | `ErrAuthRejected` | 481 | Authentication credentials rejected |
 | `ErrServiceUnavailable` | 502 | Server permanently unavailable; provider removed from pool |
-| `ErrCRCMismatch` | — | yEnc CRC32 validation failed; body is returned alongside the error |
+| `ErrCRCMismatch` | — | A supplied yEnc CRC32 did not match |
+| `ErrBodyCorrupt` | — | BODY framing, metadata, size, decoding, or integrity validation failed |
 | `ErrMaxConnections` | 502/400 | Server reported max connections reached during handshake |
 | `ErrConnectionDied` | — | TCP connection closed unexpectedly |
 | `ErrProtocolDesync` | — | Binary data received where a status line was expected |
@@ -907,7 +968,10 @@ nntppool.WithDispatchStrategy(nntppool.DispatchFIFO)
 
 `ErrArticleNotFound` uses category matching: `errors.Is(err, ErrArticleNotFound)` returns true for both 430 and 423 responses.
 
-`ErrCRCMismatch` is returned alongside a non-nil `*ArticleBody` so callers can inspect the decoded data and decide whether to discard or use it.
+High-level buffered BODY APIs never return corrupt payload as a successful body.
+They preserve `errors.Is` checks through `TransportError` and expose every
+provider attempt there. Streaming APIs surface validation failure without
+restarting after decoded bytes have crossed the caller's writer boundary.
 
 ---
 
@@ -1160,9 +1224,12 @@ err := client.AddProvider(myProvider)
 
 ### CRC mismatch on decoded bodies
 
-**Symptom**: `ErrCRCMismatch` returned alongside a non-nil `*ArticleBody`.
+**Symptom**: `ErrCRCMismatch`/`ErrBodyCorrupt` is present in a structured BODY error.
 
-**Behaviour**: The body is always returned even on CRC mismatch so callers can choose to discard or accept the data. Check `body.CRCValid` and compare `body.CRC` with `body.ExpectedCRC`. This typically indicates a corrupt article on the server side.
+**Behaviour**: Buffered BODY retrieval discards the corrupt attempt, retires its
+socket, and tries the next eligible provider. If no provider returns a validated
+body, the error retains the corrupt attempt evidence. Streaming retrieval does
+not restart after any decoded byte was delivered to the caller's writer.
 
 ### Zombie connections under idle load
 

--- a/client.go
+++ b/client.go
@@ -23,7 +23,9 @@ const (
 
 // ArticleBody holds the decoded result of a BODY command.
 type ArticleBody struct {
-	MessageID string
+	MessageID  string
+	ProviderID string
+	Attempts   []AttemptEvidence
 
 	// Decoded payload bytes. Nil when the body was streamed to an io.Writer.
 	Bytes []byte
@@ -37,7 +39,8 @@ type ArticleBody struct {
 
 	CRC         uint32
 	ExpectedCRC uint32
-	CRCValid    bool // true when ExpectedCRC != 0 && CRC == ExpectedCRC
+	CRCProvided bool
+	CRCValid    bool // true when a supplied CRC (including 00000000) matches
 
 	byteBuf []byte // internal; transferred to Bytes in Body()
 }
@@ -50,14 +53,23 @@ type ArticleHead struct {
 
 // StatResult holds the parsed result of a STAT command.
 type StatResult struct {
-	MessageID string
-	Number    int64 // article number from response (0 if no group selected)
+	MessageID  string
+	ProviderID string
+	Attempts   []AttemptEvidence
+	Number     int64 // article number from response (0 if no group selected)
 }
 
 // BodyResult is the result type for BodyAsync.
 type BodyResult struct {
 	Body *ArticleBody
 	Err  error
+}
+
+// TargetedBodyOptions confines a validated BODY request to one provider.
+type TargetedBodyOptions struct {
+	Provider       string
+	FreshTransport bool
+	Priority       bool
 }
 
 // Body retrieves and decodes an article body, buffering the decoded bytes in memory.
@@ -81,9 +93,9 @@ func (c *Client) BodyPriority(ctx context.Context, messageID string, onMeta ...f
 	payload := []byte("BODY <" + messageID + ">\r\n")
 	var respCh <-chan Response
 	if len(onMeta) > 0 {
-		respCh = c.SendPriority(ctx, payload, nil, onMeta[0])
+		respCh = c.sendValidatedBody(ctx, payload, nil, onMeta[0], true)
 	} else {
-		respCh = c.SendPriority(ctx, payload, nil)
+		respCh = c.sendValidatedBody(ctx, payload, nil, nil, true)
 	}
 	body, err := c.finishBody(messageID, nil, respCh)
 	if body != nil {
@@ -91,6 +103,56 @@ func (c *Client) BodyPriority(ctx context.Context, messageID string, onMeta ...f
 		body.byteBuf = nil
 	}
 	return body, err
+}
+
+// BodyTargeted retrieves and validates a BODY from exactly one provider. A
+// fresh transport may be required when revalidating prior corruption.
+func (c *Client) BodyTargeted(ctx context.Context, messageID string, opts TargetedBodyOptions, onMeta ...func(YEncMeta)) (*ArticleBody, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	group := c.findGroup(opts.Provider)
+	if group == nil {
+		return nil, fmt.Errorf("nntp: provider %q not found", opts.Provider)
+	}
+	var metaFn func(YEncMeta)
+	if len(onMeta) > 0 {
+		metaFn = onMeta[0]
+	}
+	payload := []byte("BODY <" + messageID + ">\r\n")
+	resp, ok, cancelled := c.tryGroupResilient(
+		ctx,
+		group,
+		payload,
+		nil,
+		metaFn,
+		opts.Priority,
+		true,
+		opts.FreshTransport,
+	)
+	if cancelled {
+		err := ctx.Err()
+		if err == nil {
+			err = c.ctx.Err()
+		}
+		return nil, &TransportError{
+			Kind:       OutcomeCancellation,
+			ProviderID: group.id,
+			Attempts:   cloneAttempts(resp.Attempts),
+			Cause:      err,
+		}
+	}
+	if !ok {
+		return nil, newTransportError(resp.Attempts, ErrConnectionDied)
+	}
+	return c.finishBody(messageID, nil, oneResponse(resp))
+}
+
+func oneResponse(resp Response) <-chan Response {
+	ch := make(chan Response, 1)
+	ch <- resp
+	close(ch)
+	return ch
 }
 
 // BodyStream retrieves and decodes an article body, streaming decoded bytes to w.
@@ -131,10 +193,7 @@ func (c *Client) Head(ctx context.Context, messageID string) (*ArticleHead, erro
 	respCh := c.Send(ctx, payload, nil)
 
 	resp := <-respCh
-	if resp.Err != nil {
-		return nil, resp.Err
-	}
-	if err := toError(resp.StatusCode, resp.Status); err != nil {
+	if err := responseError(resp); err != nil {
 		return nil, err
 	}
 
@@ -153,14 +212,15 @@ func statPayload(messageID string) []byte {
 // is returned as ErrArticleNotFound with a nil result; callers doing bulk
 // existence checks treat that as a normal miss rather than a fatal error.
 func parseStat(messageID string, resp Response) (*StatResult, error) {
-	if resp.Err != nil {
-		return nil, resp.Err
-	}
-	if err := toError(resp.StatusCode, resp.Status); err != nil {
+	if err := responseError(resp); err != nil {
 		return nil, err
 	}
 
-	result := &StatResult{MessageID: messageID}
+	result := &StatResult{
+		MessageID:  messageID,
+		ProviderID: resp.ProviderID,
+		Attempts:   cloneAttempts(resp.Attempts),
+	}
 
 	// Parse "223 <number> <message-id>" from the status line.
 	parts := strings.SplitN(resp.Status, " ", 4)
@@ -206,9 +266,9 @@ func (c *Client) doBody(ctx context.Context, messageID string, w io.Writer, onMe
 	payload := []byte("BODY <" + messageID + ">\r\n")
 	var respCh <-chan Response
 	if onMeta != nil {
-		respCh = c.Send(ctx, payload, w, onMeta)
+		respCh = c.sendValidatedBody(ctx, payload, w, onMeta, false)
 	} else {
-		respCh = c.Send(ctx, payload, w)
+		respCh = c.sendValidatedBody(ctx, payload, w, nil, false)
 	}
 	return c.finishBody(messageID, w, respCh)
 }
@@ -216,23 +276,23 @@ func (c *Client) doBody(ctx context.Context, messageID string, w io.Writer, onMe
 // finishBody waits on respCh and builds the ArticleBody result.
 func (c *Client) finishBody(messageID string, w io.Writer, respCh <-chan Response) (*ArticleBody, error) {
 	resp := <-respCh
-	if resp.Err != nil {
-		return nil, resp.Err
-	}
-	if err := toError(resp.StatusCode, resp.Status); err != nil {
+	if err := responseError(resp); err != nil {
 		return nil, err
 	}
 
 	body := &ArticleBody{
 		MessageID:     messageID,
+		ProviderID:    resp.ProviderID,
+		Attempts:      cloneAttempts(resp.Attempts),
 		BytesDecoded:  resp.Meta.BytesDecoded,
 		BytesConsumed: resp.Meta.BytesConsumed,
 		Encoding:      mapFormat(resp.Meta.Format),
 		YEnc:          resp.Meta.YEnc,
 		CRC:           resp.Meta.CRC,
 		ExpectedCRC:   resp.Meta.ExpectedCRC,
+		CRCProvided:   resp.Meta.hasCrc,
 	}
-	body.CRCValid = body.ExpectedCRC != 0 && body.CRC == body.ExpectedCRC
+	body.CRCValid = body.CRCProvided && body.CRC == body.ExpectedCRC
 
 	// When w was nil, the decoded bytes were buffered in resp.Body.
 	if w == nil {
@@ -240,11 +300,6 @@ func (c *Client) finishBody(messageID string, w io.Writer, respCh <-chan Respons
 		if len(buf) > 0 {
 			body.byteBuf = buf
 		}
-	}
-
-	// Return both the body and a CRC error so callers get data but are warned.
-	if body.ExpectedCRC != 0 && body.CRC != body.ExpectedCRC {
-		return body, ErrCRCMismatch
 	}
 
 	return body, nil

--- a/errors.go
+++ b/errors.go
@@ -1,9 +1,215 @@
 package nntppool
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"time"
 )
+
+// OutcomeKind is the transport-owned classification of one provider attempt
+// or a final pool result.
+type OutcomeKind string
+
+const (
+	OutcomeSuccess             OutcomeKind = "success"
+	OutcomeHardArticleAbsence  OutcomeKind = "hard_article_absence"
+	OutcomeTemporaryFailure    OutcomeKind = "temporary_failure"
+	OutcomeProviderUnavailable OutcomeKind = "provider_unavailable"
+	OutcomeCorruptBody         OutcomeKind = "corrupt_body"
+	OutcomeCancellation        OutcomeKind = "cancellation"
+	OutcomeTransportFailure    OutcomeKind = "transport_failure"
+	OutcomeInconclusive        OutcomeKind = "inconclusive"
+)
+
+// Operation identifies the NNTP command represented by attempt evidence.
+type Operation string
+
+const (
+	OperationUnknown Operation = "UNKNOWN"
+	OperationBody    Operation = "BODY"
+	OperationStat    Operation = "STAT"
+	OperationHead    Operation = "HEAD"
+	OperationPost    Operation = "POST"
+)
+
+// BodyValidationStatus records whether a BODY attempt crossed the complete
+// transport validation boundary.
+type BodyValidationStatus string
+
+const (
+	BodyValidationNotApplicable BodyValidationStatus = "not_applicable"
+	BodyValidationNotRequested  BodyValidationStatus = "not_requested"
+	BodyValidationValid         BodyValidationStatus = "valid"
+	BodyValidationInvalid       BodyValidationStatus = "invalid"
+	BodyValidationIncomplete    BodyValidationStatus = "incomplete"
+)
+
+// AttemptEvidence is transport-owned evidence for one bounded provider
+// attempt. The three durations intentionally remain separate.
+type AttemptEvidence struct {
+	ProviderID string
+	Operation  Operation
+	Outcome    OutcomeKind
+
+	ResponseCode   int
+	BodyValidation BodyValidationStatus
+	Cause          error
+	// ProviderResponseTimeout is true only when the response-head service
+	// deadline expired. Caller cancellation and local queue expiry leave it false.
+	ProviderResponseTimeout bool
+
+	PoolQueueDuration        time.Duration
+	PipelineHeadWaitDuration time.Duration
+	ResponseServiceDuration  time.Duration
+}
+
+// TransportError is the structured final error returned after cancellation or
+// provider exhaustion. Cause remains wrapped for errors.Is/errors.As callers.
+type TransportError struct {
+	Kind         OutcomeKind
+	ProviderID   string
+	ResponseCode int
+	Attempts     []AttemptEvidence
+	Cause        error
+}
+
+func (e *TransportError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.ProviderID != "" {
+		return fmt.Sprintf("nntp: %s from %s: %v", e.Kind, e.ProviderID, e.Cause)
+	}
+	return fmt.Sprintf("nntp: %s: %v", e.Kind, e.Cause)
+}
+
+func (e *TransportError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func operationFromPayload(payload []byte) Operation {
+	for _, candidate := range []struct {
+		prefix string
+		op     Operation
+	}{
+		{"BODY ", OperationBody},
+		{"STAT ", OperationStat},
+		{"HEAD ", OperationHead},
+		{"POST", OperationPost},
+	} {
+		if len(payload) >= len(candidate.prefix) && string(payload[:len(candidate.prefix)]) == candidate.prefix {
+			return candidate.op
+		}
+	}
+	return OperationUnknown
+}
+
+func classifyOutcome(code int, err error) OutcomeKind {
+	switch {
+	case err == nil && code >= 200 && code < 400:
+		return OutcomeSuccess
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return OutcomeCancellation
+	case errors.Is(err, ErrBodyCorrupt), errors.Is(err, ErrCRCMismatch):
+		return OutcomeCorruptBody
+	case errors.Is(err, ErrServiceUnavailable), errors.Is(err, ErrAuthRequired),
+		errors.Is(err, ErrAuthRejected), errors.Is(err, ErrQuotaExceeded),
+		errors.Is(err, ErrMaxConnections), code == 502:
+		return OutcomeProviderUnavailable
+	case code == 423 || code == 430 || errors.Is(err, ErrArticleNotFound):
+		return OutcomeHardArticleAbsence
+	case code == 451:
+		return OutcomeTemporaryFailure
+	case func() bool {
+		var protocolErr *Error
+		return errors.As(err, &protocolErr)
+	}():
+		return OutcomeInconclusive
+	case err != nil:
+		return OutcomeTransportFailure
+	default:
+		return OutcomeInconclusive
+	}
+}
+
+func cloneAttempts(attempts []AttemptEvidence) []AttemptEvidence {
+	if len(attempts) == 0 {
+		return nil
+	}
+	return append([]AttemptEvidence(nil), attempts...)
+}
+
+func newTransportError(attempts []AttemptEvidence, cause error) *TransportError {
+	kind := OutcomeInconclusive
+	haveKind := false
+	var providerID string
+	responseCode := 0
+	for _, attempt := range attempts {
+		if attempt.Outcome == OutcomeSuccess {
+			continue
+		}
+		providerID = attempt.ProviderID
+		responseCode = attempt.ResponseCode
+		if attempt.Outcome == OutcomeCancellation {
+			kind = OutcomeCancellation
+			haveKind = true
+			continue
+		}
+		if kind == OutcomeCancellation {
+			continue
+		}
+		if !haveKind {
+			kind = attempt.Outcome
+			haveKind = true
+		} else if kind != attempt.Outcome {
+			// A final result is conclusive only when every provider attempt
+			// agrees on its outcome class. Per-provider detail remains in Attempts.
+			kind = OutcomeInconclusive
+		}
+	}
+	return &TransportError{
+		Kind:         kind,
+		ProviderID:   providerID,
+		ResponseCode: responseCode,
+		Attempts:     cloneAttempts(attempts),
+		Cause:        cause,
+	}
+}
+
+func responseError(resp Response) error {
+	cause := resp.Err
+	if cause == nil {
+		cause = toError(resp.StatusCode, resp.Status)
+	}
+	if cause == nil {
+		return nil
+	}
+	if _, ok := cause.(*TransportError); ok {
+		return cause
+	}
+	if len(resp.Attempts) == 0 {
+		return cause
+	}
+	return newTransportError(resp.Attempts, cause)
+}
+
+func cancellationResponse(attempts []AttemptEvidence, cause error) Response {
+	providerID := ""
+	if len(attempts) > 0 {
+		providerID = attempts[len(attempts)-1].ProviderID
+	}
+	err := &TransportError{
+		Kind:       OutcomeCancellation,
+		ProviderID: providerID,
+		Attempts:   cloneAttempts(attempts),
+		Cause:      cause,
+	}
+	return Response{Err: err, Attempts: cloneAttempts(attempts)}
+}
 
 // Error represents an NNTP protocol-level error with a status code.
 type Error struct {
@@ -35,15 +241,16 @@ func errorCategory(code int) int {
 }
 
 var (
-	ErrArticleNotFound    = &Error{Code: 430, Message: "no such article"}
+	ErrArticleNotFound     = &Error{Code: 430, Message: "no such article"}
 	ErrPostingNotPermitted = &Error{Code: 440, Message: "posting not permitted"}
 	ErrPostingFailed       = &Error{Code: 441, Message: "posting failed"}
-	ErrAuthRequired       = &Error{Code: 480, Message: "authentication required"}
-	ErrAuthRejected       = &Error{Code: 481, Message: "authentication rejected"}
-	ErrServiceUnavailable = &Error{Code: 502, Message: "service unavailable"}
-	ErrCRCMismatch        = errors.New("nntp: yEnc CRC mismatch")
-	ErrProtocolDesync     = errors.New("nntp: protocol desync: expected status line, got binary data")
-	ErrQuotaExceeded      = errors.New("nntp: download quota exceeded")
+	ErrAuthRequired        = &Error{Code: 480, Message: "authentication required"}
+	ErrAuthRejected        = &Error{Code: 481, Message: "authentication rejected"}
+	ErrServiceUnavailable  = &Error{Code: 502, Message: "service unavailable"}
+	ErrCRCMismatch         = errors.New("nntp: yEnc CRC mismatch")
+	ErrBodyCorrupt         = errors.New("nntp: corrupt article body")
+	ErrProtocolDesync      = errors.New("nntp: protocol desync: expected status line, got binary data")
+	ErrQuotaExceeded       = errors.New("nntp: download quota exceeded")
 )
 
 // toError maps an NNTP status code to a sentinel error, or returns nil for success codes.

--- a/integration_test.go
+++ b/integration_test.go
@@ -481,7 +481,7 @@ func TestClient_SendRetryFallbackBackup(t *testing.T) {
 	}
 
 	c, err := NewClient(context.Background(), []Provider{
-		{Factory: makeFactory(430), Connections: 1},        // main: always 430
+		{Factory: makeFactory(430), Connections: 1},               // main: always 430
 		{Factory: makeFactory(223), Connections: 1, Backup: true}, // backup: 223
 	})
 	if err != nil {
@@ -553,6 +553,15 @@ func TestClient_SendRetryConnectionDiedSameProvider(t *testing.T) {
 	}
 	if got := connNum.Load(); got < 2 {
 		t.Errorf("expected at least 2 connections (stale + fresh), got %d", got)
+	}
+	if len(resp.Attempts) < 2 || resp.Attempts[len(resp.Attempts)-1].Outcome != OutcomeSuccess {
+		t.Errorf("attempts = %+v, want connection death followed by same-provider success", resp.Attempts)
+	} else {
+		for _, attempt := range resp.Attempts[:len(resp.Attempts)-1] {
+			if attempt.Outcome != OutcomeTransportFailure {
+				t.Errorf("pre-success attempt = %+v, want transport failure", attempt)
+			}
+		}
 	}
 }
 
@@ -804,7 +813,6 @@ func TestClient_FIFODispatch(t *testing.T) {
 		t.Errorf("FIFO: p1=%d p2=%d, want p1=%d p2=0", hits["p1"], hits["p2"], N)
 	}
 }
-
 
 func TestClient_FIFO430Fallthrough(t *testing.T) {
 	// Provider #1 returns 430, provider #2 returns 223.
@@ -1314,8 +1322,8 @@ func TestClient_502CommandFallsBackToBackup(t *testing.T) {
 	}
 
 	c, err := NewClient(context.Background(), []Provider{
-		{Factory: makeFactory(502), Connections: 1},                // main: always 502
-		{Factory: makeFactory(223), Connections: 1, Backup: true},  // backup: success
+		{Factory: makeFactory(502), Connections: 1},               // main: always 502
+		{Factory: makeFactory(223), Connections: 1, Backup: true}, // backup: success
 	})
 	if err != nil {
 		t.Fatalf("NewClient() error = %v", err)
@@ -1446,4 +1454,3 @@ func TestKeepalive_DeadConnection(t *testing.T) {
 		t.Fatal("timeout: Run() should have returned after keepalive detected dead connection")
 	}
 }
-

--- a/metrics.go
+++ b/metrics.go
@@ -23,10 +23,15 @@ type PingResult struct {
 // providerStats holds internal atomic counters for a single provider group.
 // Used on the hot path — no mutex, atomic only.
 type providerStats struct {
-	BytesConsumed atomic.Int64 // wire bytes consumed (used to compute AvgSpeed)
-	Missing       atomic.Int64 // 430/423 responses
-	Errors        atomic.Int64 // network errors, bad status codes
-	Ping          PingResult   // result of initial DATE ping
+	BytesConsumed       atomic.Int64 // wire bytes consumed (used to compute AvgSpeed)
+	Missing             atomic.Int64 // 430/423 responses
+	Errors              atomic.Int64 // network errors, bad status codes
+	PipelineInUse       atomic.Int64
+	BackgroundStatInUse atomic.Int64
+	Ping                PingResult // result of initial DATE ping
+	pipelineLimit       int
+	backgroundStatLimit int
+	priorityHeadroom    int
 
 	// ttfbEWMA is the exponentially weighted moving average of observed
 	// time-to-first-byte, in nanoseconds. 0 = no sample yet. Seeded from the
@@ -102,17 +107,23 @@ func speedEWMABytesPerSec(stats *providerStats) float64 {
 
 // ProviderStats is a public snapshot of one provider's metrics.
 type ProviderStats struct {
-	Name              string
-	AvgSpeed          float64 // bytes/sec average since client start
-	SpeedEWMA         float64 // bytes/sec recent throughput estimate (drives speed-aware dispatch); 0 = no sample
-	BytesConsumed     int64   // raw wire bytes consumed since client start
-	Missing           int64
-	Errors            int64
-	ActiveConnections int           // currently running connections
-	MaxConnections    int           // configured connection slots
-	AvailableSlots    int           // connection slots currently free (allowed - held)
-	TTFB              time.Duration // recent time-to-first-byte estimate (seeded from ping RTT); 0 = no sample
-	Ping              PingResult
+	Name                string
+	ProviderID          string
+	AvgSpeed            float64 // bytes/sec average since client start
+	SpeedEWMA           float64 // bytes/sec recent throughput estimate (drives speed-aware dispatch); 0 = no sample
+	BytesConsumed       int64   // raw wire bytes consumed since client start
+	Missing             int64
+	Errors              int64
+	ActiveConnections   int           // currently running connections
+	MaxConnections      int           // configured connection slots
+	AvailableSlots      int           // connection slots currently free (allowed - held)
+	TTFB                time.Duration // recent time-to-first-byte estimate (seeded from ping RTT); 0 = no sample
+	PipelineInUse       int
+	PipelineLimit       int
+	BackgroundStatInUse int
+	BackgroundStatLimit int
+	PriorityHeadroom    int
+	Ping                PingResult
 
 	// Quota fields. QuotaBytes is 0 when no quota is configured.
 	QuotaBytes    int64     // configured limit per period (0 = unlimited)

--- a/nntp.go
+++ b/nntp.go
@@ -1519,7 +1519,7 @@ func (c *NNTPConnection) readerLoop() {
 					c.stats.quotaExceeded.Store(true)
 				}
 			}
-			if resp.Err != nil {
+			if resp.Err != nil && classifyOutcome(resp.StatusCode, resp.Err) != OutcomeCancellation {
 				c.stats.Errors.Add(1)
 			} else if decoder.StatusCode == 430 || decoder.StatusCode == 423 {
 				c.stats.Missing.Add(1)

--- a/nntp.go
+++ b/nntp.go
@@ -90,7 +90,15 @@ const (
 	// issues at most one SetReadDeadline syscall per quantum instead of one per
 	// read.
 	stallDeadlineQuantum = 250 * time.Millisecond
+
+	// Abandoned BODY responses are drained only within both bounds. Reaching a
+	// bound retires the connection so obsolete pipeline data cannot delay or
+	// poison later work.
+	defaultAbandonedBodyDrainBytes   = 1 * 1024 * 1024
+	defaultAbandonedBodyDrainTimeout = 250 * time.Millisecond
 )
+
+var errAbandonedBodyDrainLimit = errors.New("nntp: abandoned BODY drain limit exceeded")
 
 // Attempt lifecycle states, coordinating the race between tryGroup's attempt
 // timer and the reader observing the first response byte. The CAS handshake
@@ -98,9 +106,10 @@ const (
 // attempt is never abandoned mid-stream; if the timer fires first the attempt
 // fails over and the reader drops the (cancelled) request.
 const (
-	attemptPending   int32 = iota // no response byte seen yet
-	attemptCommitted              // reader saw the first response byte
-	attemptAbandoned              // tryGroup timed out before any byte arrived
+	attemptPending      int32 = iota // request has not reached response head
+	attemptResponseHead              // request is the FIFO response head
+	attemptCommitted                 // decoded bytes crossed the output boundary
+	attemptAbandoned                 // request was abandoned before response head
 )
 
 type greetingError struct {
@@ -146,10 +155,14 @@ type Request struct {
 	// deadline no longer applies — the connection's rolling stall timeout does.
 	attemptDeadline time.Time
 
-	// attemptState is one of attemptPending/attemptCommitted/attemptAbandoned.
-	// The reader CASes pending→committed on the first response byte; tryGroup's
-	// timer CASes pending→abandoned on expiry. Zero value is attemptPending.
+	// attemptState coordinates response-head admission with attempt timeout.
+	// Decoded output advances responseHead→committed. Zero is attemptPending.
 	attemptState atomic.Int32
+
+	// decodedCommitted protects the v4 caller-writer contract independently of
+	// response timing: after any decoded byte crosses the writer boundary, the
+	// request must never restart on another provider.
+	decodedCommitted atomic.Bool
 
 	// sentAt is the Unix-nanosecond timestamp at which the payload was handed
 	// to the connection, used to measure time-to-first-byte. 0 = unset (the
@@ -212,13 +225,15 @@ type NNTPConnection struct {
 
 	Greeting NNTPResponse
 
-	firstReq          *Request      // bootstrap request from connection slot
-	idleTimeout       time.Duration // 0 = no idle timeout
-	stallTimeout      time.Duration // rolling body-progress deadline; 0 = disabled
-	keepaliveInterval time.Duration // 0 = no keepalive
-	keepaliveCommand  string        // NNTP command for keepalive probe (e.g. "DATE")
-	providerName      string        // set by runConnSlot; used for error context
-	userAgent         string
+	firstReq              *Request      // bootstrap request from connection slot
+	idleTimeout           time.Duration // 0 = no idle timeout
+	stallTimeout          time.Duration // rolling body-progress deadline; 0 = disabled
+	abandonedDrainBytes   int           // maximum obsolete BODY bytes to drain
+	abandonedDrainTimeout time.Duration // maximum obsolete BODY drain duration
+	keepaliveInterval     time.Duration // 0 = no keepalive
+	keepaliveCommand      string        // NNTP command for keepalive probe (e.g. "DATE")
+	providerName          string        // set by runConnSlot; used for error context
+	userAgent             string
 
 	stats *providerStats // nil for standalone connections
 
@@ -279,11 +294,13 @@ func newNNTPConnectionFromConn(ctx context.Context, conn net.Conn, inflightLimit
 		// Default bodySem to the full pipeline depth (no separate BODY bound);
 		// runConnSlot overrides this to Provider.Inflight when a deeper STAT
 		// pipeline is configured. Standalone connections keep them equal.
-		bodySem:   make(chan struct{}, inflightLimit),
-		rb:        rb,
-		stats:     stats,
-		done:      make(chan struct{}),
-		userAgent: userAgent,
+		bodySem:               make(chan struct{}, inflightLimit),
+		rb:                    rb,
+		stats:                 stats,
+		done:                  make(chan struct{}),
+		userAgent:             userAgent,
+		abandonedDrainBytes:   defaultAbandonedBodyDrainBytes,
+		abandonedDrainTimeout: defaultAbandonedBodyDrainTimeout,
 	}
 
 	// Server greeting is sent immediately upon connect.
@@ -386,12 +403,17 @@ func keepaliveExpectedCode(cmd string) int {
 // has a single-line reply and no payload, so it may pipeline to the deeper
 // StatInflight depth without acquiring a bodySem slot.
 var statCmdPrefix = []byte("STAT ")
+var bodyCmdPrefix = []byte("BODY ")
 
 // isCheapCommand reports whether payload is a bodyless command that should
 // bypass the BODY concurrency bound (bodySem) and pipeline to the full
 // inflightSem (StatInflight) depth.
 func isCheapCommand(payload []byte) bool {
 	return bytes.HasPrefix(payload, statCmdPrefix)
+}
+
+func isBodyCommand(payload []byte) bool {
+	return bytes.HasPrefix(payload, bodyCmdPrefix)
 }
 
 func failRequest(ch chan Response, err error) {
@@ -580,7 +602,7 @@ func (g *connGate) snapshot() (maxSlots, running int) {
 
 // runConnSlot is the slot goroutine that manages the lifecycle of a single
 // connection: IDLE → CONNECTING → ACTIVE → (death/idle) → IDLE.
-func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Request, hotReqCh <-chan *Request, hotPrioCh <-chan *Request, factory ConnFactory, inflight int, statInflight int, auth Auth, userAgent string, idleTimeout time.Duration, stallTimeout time.Duration, keepaliveInterval time.Duration, keepaliveCommand string, gate *connGate, stats *providerStats, providerName string, wg *sync.WaitGroup) {
+func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Request, hotReqCh <-chan *Request, hotPrioCh <-chan *Request, factory ConnFactory, inflight int, statInflight int, auth Auth, userAgent string, idleTimeout time.Duration, stallTimeout time.Duration, abandonedDrainBytes int, abandonedDrainTimeout time.Duration, keepaliveInterval time.Duration, keepaliveCommand string, gate *connGate, stats *providerStats, providerName string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	// Shared read buffer persists across reconnections to avoid re-growing.
@@ -676,6 +698,8 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 		nc.firstReq = firstReq
 		nc.idleTimeout = idleTimeout
 		nc.stallTimeout = stallTimeout
+		nc.abandonedDrainBytes = abandonedDrainBytes
+		nc.abandonedDrainTimeout = abandonedDrainTimeout
 		nc.providerName = providerName
 		nc.hotReqCh = hotReqCh
 		nc.hotPrioCh = hotPrioCh
@@ -703,6 +727,21 @@ type writerRef struct {
 
 func (wr *writerRef) Write(p []byte) (int, error) {
 	return wr.w.Write(p)
+}
+
+type attemptWriter struct {
+	req *Request
+	w   io.Writer
+}
+
+func (w *attemptWriter) Write(p []byte) (int, error) {
+	if len(p) > 0 {
+		// Mark before entering a potentially blocking writer. Once decoded bytes
+		// cross this boundary, cancellation cannot safely restart the request.
+		w.req.decodedCommitted.Store(true)
+		w.req.attemptState.CompareAndSwap(attemptResponseHead, attemptCommitted)
+	}
+	return w.w.Write(p)
 }
 
 func (c *NNTPConnection) Run() {
@@ -1112,6 +1151,7 @@ func (c *NNTPConnection) readerLoop() {
 		if req.Ctx == nil {
 			req.Ctx = context.Background()
 		}
+		req.attemptState.CompareAndSwap(attemptPending, attemptResponseHead)
 
 		resp := Response{
 			Request: req,
@@ -1120,8 +1160,8 @@ func (c *NNTPConnection) readerLoop() {
 			onMeta: req.OnMeta,
 		}
 
-		// If the request is cancelled after send, we must still drain its response off the wire,
-		// but we don't deliver it.
+		// If the request is cancelled after send, drain only a bounded prefix of
+		// a BODY response, then retire the socket.
 		deliver := true
 		select {
 		case <-req.Ctx.Done():
@@ -1134,6 +1174,9 @@ func (c *NNTPConnection) readerLoop() {
 			out = io.Discard
 		} else if out == nil {
 			out = &resp.Body
+		}
+		if deliver && isBodyCommand(req.Payload) {
+			out = &attemptWriter{req: req, w: out}
 		}
 
 		// Allow us to switch output to io.Discard if the request is cancelled while
@@ -1149,22 +1192,39 @@ func (c *NNTPConnection) readerLoop() {
 		lastBytes := 0
 		var stallDeadline time.Time
 		var firstByteAt time.Time
+		var drainStarted time.Time
+		drainStartConsumed := 0
 		respStart := time.Now()
-		err := c.rb.feedUntilDone(c.conn, &decoder, outRef, func(wireBytes int) (time.Time, bool) {
+		err := c.rb.feedUntilDoneControlled(c.conn, &decoder, outRef, func(wireBytes, consumedBytes int) (time.Time, bool, int, error) {
 			if deliver {
 				select {
 				case <-req.Ctx.Done():
 					deliver = false
 					outRef.w = io.Discard
+					drainStarted = time.Now()
+					drainStartConsumed = consumedBytes
 				default:
 				}
+			}
+			if !deliver && isBodyCommand(req.Payload) {
+				if drainStarted.IsZero() {
+					drainStarted = time.Now()
+					drainStartConsumed = consumedBytes
+				}
+				remaining := c.abandonedDrainBytes - (consumedBytes - drainStartConsumed)
+				if c.abandonedDrainBytes > 0 && remaining <= 0 {
+					return time.Time{}, false, 0, errAbandonedBodyDrainLimit
+				}
+				if c.abandonedDrainTimeout > 0 {
+					return drainStarted.Add(c.abandonedDrainTimeout), true, max(remaining, 0), nil
+				}
+				return time.Time{}, false, max(remaining, 0), nil
 			}
 			if wireBytes > lastBytes {
 				lastBytes = wireBytes
 				if firstByteAt.IsZero() {
 					firstByteAt = time.Now()
 				}
-				req.attemptState.CompareAndSwap(attemptPending, attemptCommitted)
 				if stall > 0 {
 					if dl := time.Now().Add(stall); dl.Sub(stallDeadline) >= stallDeadlineQuantum {
 						stallDeadline = dl
@@ -1174,11 +1234,13 @@ func (c *NNTPConnection) readerLoop() {
 			parentDL, hasParent := req.Ctx.Deadline()
 			switch {
 			case lastBytes == 0 && !req.attemptDeadline.IsZero():
-				return minDeadline(req.attemptDeadline, parentDL, hasParent)
+				dl, ok := minDeadline(req.attemptDeadline, parentDL, hasParent)
+				return dl, ok, 0, nil
 			case lastBytes > 0 && stall > 0:
-				return minDeadline(stallDeadline, parentDL, hasParent)
+				dl, ok := minDeadline(stallDeadline, parentDL, hasParent)
+				return dl, ok, 0, nil
 			default:
-				return parentDL, hasParent
+				return parentDL, hasParent, 0, nil
 			}
 		})
 		if err != nil {
@@ -1273,6 +1335,14 @@ func (c *NNTPConnection) readerLoop() {
 		<-c.inflightSem
 		if req.heldBody {
 			<-c.bodySem
+		}
+
+		// A BODY parse/decode/writer/drain failure can leave unread framing in
+		// either the socket or shared read buffer. Never reuse that connection.
+		if resp.Err != nil && isBodyCommand(req.Payload) {
+			_ = c.conn.Close()
+			c.failOutstanding()
+			return
 		}
 
 		// If we hit a timeout, cancellation-related network error, or protocol
@@ -1386,6 +1456,13 @@ type Provider struct {
 	// truly stalled one is torn down. 0 defaults to 8s; negative disables it
 	// (only the caller's context deadline applies).
 	StallTimeout time.Duration
+
+	// AbandonedBodyDrainBytes and AbandonedBodyDrainTimeout bound cleanup after
+	// a sent BODY request is canceled. Reaching either bound retires the
+	// connection rather than letting obsolete payload block newer work. Zero
+	// selects the conservative library default for that bound.
+	AbandonedBodyDrainBytes   int
+	AbandonedBodyDrainTimeout time.Duration
 
 	// KeepaliveInterval, if non-zero, sends a lightweight NNTP command
 	// periodically when the connection is idle, to detect zombie connections
@@ -1684,6 +1761,14 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 	} else if stall < 0 {
 		stall = 0
 	}
+	drainBytes := p.AbandonedBodyDrainBytes
+	if drainBytes <= 0 {
+		drainBytes = defaultAbandonedBodyDrainBytes
+	}
+	drainTimeout := p.AbandonedBodyDrainTimeout
+	if drainTimeout <= 0 {
+		drainTimeout = defaultAbandonedBodyDrainTimeout
+	}
 
 	// Resolve keepalive settings. If SkipPing is true and no explicit command
 	// is set, keepalive is disabled (we don't know which command the server supports).
@@ -1701,7 +1786,7 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 
 	for range p.Connections {
 		c.wg.Add(1)
-		go runConnSlot(gctx, g.reqCh, g.prioCh, g.hotReqCh, g.hotPrioCh, factory, inflight, statInflight, p.Auth, p.UserAgent, p.IdleTimeout, stall, kaInterval, kaCmd, gate, &g.stats, name, &c.wg)
+		go runConnSlot(gctx, g.reqCh, g.prioCh, g.hotReqCh, g.hotPrioCh, factory, inflight, statInflight, p.Auth, p.UserAgent, p.IdleTimeout, stall, drainBytes, drainTimeout, kaInterval, kaCmd, gate, &g.stats, name, &c.wg)
 	}
 
 	return g
@@ -2153,7 +2238,7 @@ func hostSkipped(host string, skipHosts *[4]string, count int) bool {
 // had already started streaming bytes (the reader committed). Such an attempt
 // must not be retried or failed over when a caller-supplied writer is in use.
 func attemptCommittedResp(resp Response) bool {
-	return resp.Request != nil && resp.Request.attemptState.Load() == attemptCommitted
+	return resp.Request != nil && resp.Request.decodedCommitted.Load()
 }
 
 // maxSpeedScore is the highest multiplier speed-aware dispatch applies to a

--- a/nntp.go
+++ b/nntp.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net"
 	"sort"
 	"sync"
@@ -37,7 +38,10 @@ func isConnectionDeathError(err error) bool {
 		return true
 	}
 	var netErr net.Error
-	return errors.As(err, &netErr)
+	if errors.As(err, &netErr) {
+		return !netErr.Timeout()
+	}
+	return false
 }
 
 const (
@@ -71,9 +75,10 @@ const (
 	// retry uses a fresh connection on the same provider.
 	maxConnDiedRetries = 2
 
-	// minAttemptTimeout is the floor (and default) for the per-attempt timeout
-	// that bounds dispatch + time-to-first-response-byte. Once response bytes
-	// start flowing, the rolling stall timeout takes over instead.
+	// minAttemptTimeout is the floor (and default) for the provider response
+	// timeout. It begins only when a request reaches FIFO response head and
+	// bounds time-to-first-response-byte. Once response bytes start flowing,
+	// the rolling stall timeout takes over instead.
 	minAttemptTimeout = 2 * time.Second
 
 	// maxAttemptTimeout caps the adaptive per-attempt timeout derived from a
@@ -96,20 +101,22 @@ const (
 	// poison later work.
 	defaultAbandonedBodyDrainBytes   = 1 * 1024 * 1024
 	defaultAbandonedBodyDrainTimeout = 250 * time.Millisecond
+	temporaryRetryMinDelay           = 10 * time.Millisecond
+	temporaryRetryJitter             = 15 * time.Millisecond
 )
 
 var errAbandonedBodyDrainLimit = errors.New("nntp: abandoned BODY drain limit exceeded")
+var errFreshTransportRequired = errors.New("nntp: fresh transport required")
+var errBackgroundStatWindowFull = errors.New("nntp: background STAT window full")
 
-// Attempt lifecycle states, coordinating the race between tryGroup's attempt
-// timer and the reader observing the first response byte. The CAS handshake
-// guarantees exactly one of them "wins": if the reader commits first the
-// attempt is never abandoned mid-stream; if the timer fires first the attempt
-// fails over and the reader drops the (cancelled) request.
+// Attempt lifecycle states distinguish local queueing, FIFO response-head
+// service, decoded output commitment, and caller abandonment. This prevents a
+// cancellation from restarting a request after decoded bytes crossed a caller
+// writer boundary, including bytes that were already buffered locally.
 const (
 	attemptPending      int32 = iota // request has not reached response head
 	attemptResponseHead              // request is the FIFO response head
 	attemptCommitted                 // decoded bytes crossed the output boundary
-	attemptAbandoned                 // request was abandoned before response head
 )
 
 type greetingError struct {
@@ -134,6 +141,11 @@ type Request struct {
 	// Optional: decoded body bytes are streamed here. If nil, they are buffered into Response.Body.
 	BodyWriter io.Writer
 
+	// ValidateBody enables complete yEnc framing/integrity validation. It is
+	// set by the high-level BODY APIs; raw Send remains source/behavior compatible.
+	ValidateBody   bool
+	FreshTransport bool
+
 	// Optional: called with yEnc metadata once =ybegin/=ypart headers are parsed, before body decoding.
 	OnMeta func(YEncMeta)
 
@@ -149,13 +161,11 @@ type Request struct {
 	// otherwise (e.g. 440 posting not allowed). Buffered with capacity 1.
 	postReadyCh chan error
 
-	// attemptDeadline bounds dispatch + time-to-first-response-byte for this
-	// attempt. Zero means no such bound (e.g. POST and keepalive requests).
-	// Once the reader sees the first byte the attempt is committed and this
-	// deadline no longer applies — the connection's rolling stall timeout does.
-	attemptDeadline time.Time
+	// responseTimeout starts only when this request becomes FIFO response head.
+	// Pool queue and pipeline-head wait remain governed solely by the caller ctx.
+	responseTimeout time.Duration
 
-	// attemptState coordinates response-head admission with attempt timeout.
+	// attemptState records response-head admission and decoded commitment.
 	// Decoded output advances responseHead→committed. Zero is attemptPending.
 	attemptState atomic.Int32
 
@@ -164,20 +174,26 @@ type Request struct {
 	// request must never restart on another provider.
 	decodedCommitted atomic.Bool
 
-	// sentAt is the Unix-nanosecond timestamp at which the payload was handed
-	// to the connection, used to measure time-to-first-byte. 0 = unset (the
-	// request is not measured, e.g. POST/keepalive).
-	sentAt atomic.Int64
+	// submittedAt, writtenAt, and responseHeadAt delimit the three transport
+	// timing components exposed in AttemptEvidence.
+	submittedAt    time.Time
+	writtenAt      atomic.Int64
+	responseHeadAt atomic.Int64
 
 	// heldBody is set by writeLoop when this (body-bearing) request acquired a
 	// bodySem slot, so readerLoop releases exactly the slots that were taken.
 	// Bodyless STAT requests never acquire bodySem and leave this false.
-	heldBody bool
+	heldBody           bool
+	heldBackgroundStat bool
+	heldPipeline       bool
+	Priority           bool
 }
 
 type Response struct {
 	StatusCode int
 	Status     string
+	ProviderID string
+	Attempts   []AttemptEvidence
 
 	// For non-body multiline responses (CAPABILITIES, etc).
 	Lines []string
@@ -218,14 +234,17 @@ type NNTPConnection struct {
 	// never increases the number of BODY responses buffered/streamed at once.
 	// Bodyless STAT commands acquire only inflightSem and so pipeline to the
 	// deeper StatInflight depth.
-	inflightSem chan struct{}
-	bodySem     chan struct{}
+	inflightSem         chan struct{}
+	bodySem             chan struct{}
+	backgroundStatSem   chan struct{}
+	backgroundStatFreed chan struct{}
 
 	rb readBuffer
 
 	Greeting NNTPResponse
 
 	firstReq              *Request      // bootstrap request from connection slot
+	secondReq             *Request      // normal request deferred behind bootstrap priority
 	idleTimeout           time.Duration // 0 = no idle timeout
 	stallTimeout          time.Duration // rolling body-progress deadline; 0 = disabled
 	abandonedDrainBytes   int           // maximum obsolete BODY bytes to drain
@@ -233,6 +252,8 @@ type NNTPConnection struct {
 	keepaliveInterval     time.Duration // 0 = no keepalive
 	keepaliveCommand      string        // NNTP command for keepalive probe (e.g. "DATE")
 	providerName          string        // set by runConnSlot; used for error context
+	providerID            string        // stable identity exposed in results/evidence
+	createdAt             time.Time
 	userAgent             string
 
 	stats *providerStats // nil for standalone connections
@@ -240,7 +261,7 @@ type NNTPConnection struct {
 	done   chan struct{}
 	doneMu sync.Once
 
-	failMu sync.Once
+	failMu sync.Mutex
 }
 
 func newNetConn(ctx context.Context, addr string, tlsConfig *tls.Config, keepAlive time.Duration) (net.Conn, error) {
@@ -295,12 +316,15 @@ func newNNTPConnectionFromConn(ctx context.Context, conn net.Conn, inflightLimit
 		// runConnSlot overrides this to Provider.Inflight when a deeper STAT
 		// pipeline is configured. Standalone connections keep them equal.
 		bodySem:               make(chan struct{}, inflightLimit),
+		backgroundStatSem:     make(chan struct{}, inflightLimit),
+		backgroundStatFreed:   make(chan struct{}, 1),
 		rb:                    rb,
 		stats:                 stats,
 		done:                  make(chan struct{}),
 		userAgent:             userAgent,
 		abandonedDrainBytes:   defaultAbandonedBodyDrainBytes,
 		abandonedDrainTimeout: defaultAbandonedBodyDrainTimeout,
+		createdAt:             time.Now(),
 	}
 
 	// Server greeting is sent immediately upon connect.
@@ -426,28 +450,28 @@ func failRequest(ch chan Response, err error) {
 }
 
 func (c *NNTPConnection) failOutstanding() {
-	c.failMu.Do(func() {
-		connErr := error(ErrConnectionDied)
-		if c.providerName != "" {
-			connErr = fmt.Errorf("%s: %w", c.providerName, ErrConnectionDied)
-		}
-		for {
-			select {
-			case req := <-c.pending:
-				if req == nil {
-					continue
-				}
-				failRequest(req.RespCh, connErr)
-				// Best-effort inflight release (not strictly needed once we're shutting down).
-				select {
-				case <-c.inflightSem:
-				default:
-				}
-			default:
-				return
+	c.failMu.Lock()
+	defer c.failMu.Unlock()
+	connErr := error(ErrConnectionDied)
+	if c.providerName != "" {
+		connErr = fmt.Errorf("%s: %w", c.providerName, ErrConnectionDied)
+	}
+	for {
+		select {
+		case req := <-c.pending:
+			if req == nil {
+				continue
 			}
+			c.releaseRequestPending(req)
+			failRequest(req.RespCh, connErr)
+			select {
+			case <-c.inflightSem:
+			default:
+			}
+		default:
+			return
 		}
-	})
+	}
 }
 
 func (c *NNTPConnection) Close() error {
@@ -602,34 +626,61 @@ func (g *connGate) snapshot() (maxSlots, running int) {
 
 // runConnSlot is the slot goroutine that manages the lifecycle of a single
 // connection: IDLE → CONNECTING → ACTIVE → (death/idle) → IDLE.
-func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Request, hotReqCh <-chan *Request, hotPrioCh <-chan *Request, factory ConnFactory, inflight int, statInflight int, auth Auth, userAgent string, idleTimeout time.Duration, stallTimeout time.Duration, abandonedDrainBytes int, abandonedDrainTimeout time.Duration, keepaliveInterval time.Duration, keepaliveCommand string, gate *connGate, stats *providerStats, providerName string, wg *sync.WaitGroup) {
+func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Request, hotReqCh <-chan *Request, hotPrioCh <-chan *Request, factory ConnFactory, inflight int, statInflight int, backgroundStatInflight int, auth Auth, userAgent string, idleTimeout time.Duration, stallTimeout time.Duration, abandonedDrainBytes int, abandonedDrainTimeout time.Duration, keepaliveInterval time.Duration, keepaliveCommand string, gate *connGate, stats *providerStats, providerName, providerID string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	// Shared read buffer persists across reconnections to avoid re-growing.
 	var sharedBuf readBuffer
+	var carriedReq *Request
 
 	for {
 		// IDLE: wait for a request (zero TCP resources).
 		// Prefer priority requests over normal ones.
 		var firstReq *Request
+		var secondReq *Request
 		var ok bool
-		select {
-		case firstReq, ok = <-prioCh:
-			if !ok {
-				return
+		if carriedReq != nil {
+			firstReq, ok = carriedReq, true
+			carriedReq = nil
+			select {
+			case priorityReq, priorityOK := <-prioCh:
+				if !priorityOK {
+					failRequest(firstReq.RespCh, ctx.Err())
+					return
+				}
+				secondReq = firstReq
+				firstReq = priorityReq
+			default:
 			}
-		default:
+		} else {
 			select {
 			case firstReq, ok = <-prioCh:
 				if !ok {
 					return
 				}
-			case firstReq, ok = <-reqCh:
-				if !ok {
-					return // channel closed, shut down
+			default:
+				select {
+				case firstReq, ok = <-prioCh:
+					if !ok {
+						return
+					}
+				case firstReq, ok = <-reqCh:
+					if !ok {
+						return // channel closed, shut down
+					}
+					select {
+					case priorityReq, priorityOK := <-prioCh:
+						if !priorityOK {
+							failRequest(firstReq.RespCh, ctx.Err())
+							return
+						}
+						secondReq = firstReq
+						firstReq = priorityReq
+					default:
+					}
+				case <-ctx.Done():
+					return
 				}
-			case <-ctx.Done():
-				return
 			}
 		}
 
@@ -637,6 +688,7 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 		select {
 		case <-firstReq.Ctx.Done():
 			failRequest(firstReq.RespCh, firstReq.Ctx.Err())
+			carriedReq = secondReq
 			continue
 		default:
 		}
@@ -645,6 +697,7 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 		if !gate.enter(ctx, firstReq.Ctx) {
 			// Slot or request context cancelled while waiting at the gate.
 			failRequest(firstReq.RespCh, context.Canceled)
+			carriedReq = secondReq
 			continue
 		}
 
@@ -653,6 +706,7 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 		if err != nil {
 			gate.exit()
 			failRequest(firstReq.RespCh, fmt.Errorf("%s: %w", providerName, err))
+			carriedReq = secondReq
 			// Backoff before retrying to avoid thrashing.
 			select {
 			case <-time.After(connFailureBackoff):
@@ -669,6 +723,7 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 		if err != nil {
 			_ = conn.Close()
 			failRequest(firstReq.RespCh, fmt.Errorf("%s: %w", providerName, err))
+			carriedReq = secondReq
 
 			if errors.Is(err, ErrMaxConnections) {
 				// Server said "max connections" — throttle and use longer backoff.
@@ -695,12 +750,15 @@ func runConnSlot(ctx context.Context, reqCh <-chan *Request, prioCh <-chan *Requ
 		// allows STAT to reach statInflight. When statInflight == inflight this
 		// is identical to the default (both caps equal).
 		nc.bodySem = make(chan struct{}, inflight)
+		nc.backgroundStatSem = make(chan struct{}, backgroundStatInflight)
 		nc.firstReq = firstReq
+		nc.secondReq = secondReq
 		nc.idleTimeout = idleTimeout
 		nc.stallTimeout = stallTimeout
 		nc.abandonedDrainBytes = abandonedDrainBytes
 		nc.abandonedDrainTimeout = abandonedDrainTimeout
 		nc.providerName = providerName
+		nc.providerID = providerID
 		nc.hotReqCh = hotReqCh
 		nc.hotPrioCh = hotPrioCh
 		nc.keepaliveInterval = keepaliveInterval
@@ -734,6 +792,57 @@ type attemptWriter struct {
 	w   io.Writer
 }
 
+func markRequestWritten(req *Request) {
+	now := time.Now().UnixNano()
+	req.writtenAt.Store(now)
+}
+
+func (c *NNTPConnection) acquireBackgroundStat(req *Request) error {
+	if !isCheapCommand(req.Payload) || req.Priority {
+		return nil
+	}
+	select {
+	case c.backgroundStatSem <- struct{}{}:
+		req.heldBackgroundStat = true
+		if c.stats != nil {
+			c.stats.BackgroundStatInUse.Add(1)
+		}
+		return nil
+	default:
+		return errBackgroundStatWindowFull
+	}
+}
+
+func (c *NNTPConnection) releaseBackgroundStat(req *Request) {
+	if !req.heldBackgroundStat {
+		return
+	}
+	req.heldBackgroundStat = false
+	<-c.backgroundStatSem
+	if c.stats != nil {
+		c.stats.BackgroundStatInUse.Add(-1)
+	}
+	select {
+	case c.backgroundStatFreed <- struct{}{}:
+	default:
+	}
+}
+
+func (c *NNTPConnection) markRequestPending(req *Request) {
+	req.heldPipeline = true
+	if c.stats != nil {
+		c.stats.PipelineInUse.Add(1)
+	}
+}
+
+func (c *NNTPConnection) releaseRequestPending(req *Request) {
+	c.releaseBackgroundStat(req)
+	if req.heldPipeline && c.stats != nil {
+		c.stats.PipelineInUse.Add(-1)
+	}
+	req.heldPipeline = false
+}
+
 func (w *attemptWriter) Write(p []byte) (int, error) {
 	if len(p) > 0 {
 		// Mark before entering a potentially blocking writer. Once decoded bytes
@@ -745,7 +854,16 @@ func (w *attemptWriter) Write(p []byte) (int, error) {
 }
 
 func (c *NNTPConnection) Run() {
+	var unsent *Request
+	deferredNormal := c.secondReq
+	c.secondReq = nil
 	defer func() {
+		if unsent != nil {
+			failRequest(unsent.RespCh, ErrConnectionDied)
+		}
+		if deferredNormal != nil {
+			failRequest(deferredNormal.RespCh, ErrConnectionDied)
+		}
 		c.cancel()
 		_ = c.conn.Close()
 		c.failOutstanding()
@@ -784,10 +902,15 @@ func (c *NNTPConnection) Run() {
 	// Process the bootstrap request injected by runConnSlot, if any.
 	if c.firstReq != nil {
 		req := c.firstReq
+		unsent = req
 		c.firstReq = nil
 
 		if req.Ctx == nil {
 			req.Ctx = context.Background()
+		}
+		if req.FreshTransport && c.createdAt.Before(req.submittedAt) {
+			failRequest(req.RespCh, errFreshTransportRequired)
+			return
 		}
 
 		// Check cancellation.
@@ -824,12 +947,21 @@ func (c *NNTPConnection) Run() {
 				return
 			}
 		}
+		if err := c.acquireBackgroundStat(req); err != nil {
+			<-c.inflightSem
+			if req.heldBody {
+				<-c.bodySem
+			}
+			failRequest(req.RespCh, err)
+			goto mainLoop
+		}
 
 		dl, hasDL := req.writeDeadline()
 		setWriteDeadline(dl, hasDL)
 
 		if _, err := bw.Write(req.Payload); err != nil {
 			<-c.inflightSem
+			c.releaseBackgroundStat(req)
 			failRequest(req.RespCh, err)
 			_ = c.conn.Close()
 			c.failOutstanding()
@@ -846,7 +978,9 @@ func (c *NNTPConnection) Run() {
 				return
 			}
 			req.postReadyCh = make(chan error, 1)
+			c.markRequestPending(req)
 			c.pending <- req
+			unsent = nil
 			// Block here — no other request can be written while we wait.
 			select {
 			case postErr := <-req.postReadyCh:
@@ -881,8 +1015,10 @@ func (c *NNTPConnection) Run() {
 					return
 				}
 			}
-			req.sentAt.Store(time.Now().UnixNano())
+			markRequestWritten(req)
+			c.markRequestPending(req)
 			c.pending <- req
+			unsent = nil
 		}
 	}
 
@@ -947,29 +1083,77 @@ mainLoop:
 		var ok bool
 		var didKeepalive bool
 		if c.prioCh != nil {
-			// Try hot priority (non-blocking).
-			select {
-			case req, ok = <-c.hotPrioCh:
-			default:
-				// Try hot normal (non-blocking).
+			takePriority := func() (*Request, bool, bool) {
 				select {
-				case req, ok = <-c.hotReqCh:
+				case priorityReq, priorityOK := <-c.hotPrioCh:
+					return priorityReq, priorityOK, true
 				default:
-					// Blocking: wait on all channels.
+				}
+				select {
+				case priorityReq, priorityOK := <-c.prioCh:
+					return priorityReq, priorityOK, true
+				default:
+					return nil, false, false
+				}
+			}
+
+			var gotPriority bool
+			blockedDeferredStat := deferredNormal != nil &&
+				isCheapCommand(deferredNormal.Payload) &&
+				!deferredNormal.Priority &&
+				len(c.backgroundStatSem) == cap(c.backgroundStatSem)
+			req, ok, gotPriority = takePriority()
+			if blockedDeferredStat && !gotPriority {
+				select {
+				case req, ok = <-c.hotPrioCh:
+					gotPriority = true
+				case req, ok = <-c.prioCh:
+					gotPriority = true
+				case <-c.backgroundStatFreed:
+				case <-c.ctx.Done():
+					<-c.inflightSem
+					return
+				}
+			}
+			if !gotPriority {
+				selectedNormal := false
+				if deferredNormal != nil {
+					req, ok = deferredNormal, true
+					deferredNormal = nil
+					selectedNormal = true
+				} else {
 					select {
-					case req, ok = <-c.hotPrioCh:
 					case req, ok = <-c.hotReqCh:
-					case req, ok = <-c.prioCh:
-					case req, ok = <-c.reqCh:
-					case <-c.ctx.Done():
-						<-c.inflightSem
-						return
-					case <-idleCh:
-						<-c.inflightSem
-						c.waitForInflightDrain()
-						return
-					case <-keepaliveCh:
-						didKeepalive = true
+						selectedNormal = true
+					default:
+						select {
+						case req, ok = <-c.reqCh:
+							selectedNormal = true
+						default:
+							select {
+							case req, ok = <-c.hotPrioCh:
+							case req, ok = <-c.prioCh:
+							case req, ok = <-c.hotReqCh:
+								selectedNormal = true
+							case req, ok = <-c.reqCh:
+								selectedNormal = true
+							case <-c.ctx.Done():
+								<-c.inflightSem
+								return
+							case <-idleCh:
+								<-c.inflightSem
+								c.waitForInflightDrain()
+								return
+							case <-keepaliveCh:
+								didKeepalive = true
+							}
+						}
+					}
+				}
+				if selectedNormal {
+					if priorityReq, priorityOK, available := takePriority(); available {
+						deferredNormal = req
+						req, ok = priorityReq, priorityOK
 					}
 				}
 			}
@@ -1026,6 +1210,7 @@ mainLoop:
 			<-c.inflightSem
 			return
 		}
+		unsent = req
 		if req.Ctx == nil {
 			req.Ctx = context.Background()
 		}
@@ -1049,6 +1234,11 @@ mainLoop:
 			continue
 		default:
 		}
+		if req.FreshTransport && c.createdAt.Before(req.submittedAt) {
+			<-c.inflightSem
+			failRequest(req.RespCh, errFreshTransportRequired)
+			return
+		}
 
 		// Body-bearing requests additionally take a bodySem slot so concurrent
 		// bodies stay bounded by Inflight even when the pipeline (inflightSem)
@@ -1066,6 +1256,19 @@ mainLoop:
 				return
 			}
 		}
+		if err := c.acquireBackgroundStat(req); err != nil {
+			<-c.inflightSem
+			if req.heldBody {
+				<-c.bodySem
+			}
+			if errors.Is(err, errBackgroundStatWindowFull) {
+				deferredNormal = req
+				unsent = nil
+				continue
+			}
+			failRequest(req.RespCh, err)
+			continue
+		}
 
 		// per-request write deadline (cached to avoid redundant syscalls)
 		dl, hasDL := req.writeDeadline()
@@ -1074,6 +1277,7 @@ mainLoop:
 		// pipeline write (buffered; flushed at top of loop before blocking)
 		if _, err := bw.Write(req.Payload); err != nil {
 			<-c.inflightSem
+			c.releaseBackgroundStat(req)
 			failRequest(req.RespCh, err)
 			_ = c.conn.Close()
 			c.failOutstanding()
@@ -1091,7 +1295,9 @@ mainLoop:
 				return
 			}
 			req.postReadyCh = make(chan error, 1)
+			c.markRequestPending(req)
 			c.pending <- req
+			unsent = nil
 			select {
 			case postErr := <-req.postReadyCh:
 				if postErr != nil {
@@ -1126,8 +1332,10 @@ mainLoop:
 				}
 			}
 			// track FIFO ordering (after writes succeed to avoid send on closed channel)
-			req.sentAt.Store(time.Now().UnixNano())
+			markRequestWritten(req)
+			c.markRequestPending(req)
 			c.pending <- req
+			unsent = nil
 		}
 	}
 }
@@ -1151,6 +1359,7 @@ func (c *NNTPConnection) readerLoop() {
 		if req.Ctx == nil {
 			req.Ctx = context.Background()
 		}
+		req.responseHeadAt.Store(time.Now().UnixNano())
 		req.attemptState.CompareAndSwap(attemptPending, attemptResponseHead)
 
 		resp := Response{
@@ -1195,6 +1404,10 @@ func (c *NNTPConnection) readerLoop() {
 		var drainStarted time.Time
 		drainStartConsumed := 0
 		respStart := time.Now()
+		var responseDeadline time.Time
+		if req.responseTimeout > 0 {
+			responseDeadline = respStart.Add(req.responseTimeout)
+		}
 		err := c.rb.feedUntilDoneControlled(c.conn, &decoder, outRef, func(wireBytes, consumedBytes int) (time.Time, bool, int, error) {
 			if deliver {
 				select {
@@ -1233,8 +1446,8 @@ func (c *NNTPConnection) readerLoop() {
 			}
 			parentDL, hasParent := req.Ctx.Deadline()
 			switch {
-			case lastBytes == 0 && !req.attemptDeadline.IsZero():
-				dl, ok := minDeadline(req.attemptDeadline, parentDL, hasParent)
+			case lastBytes == 0 && !responseDeadline.IsZero():
+				dl, ok := minDeadline(responseDeadline, parentDL, hasParent)
 				return dl, ok, 0, nil
 			case lastBytes > 0 && stall > 0:
 				dl, ok := minDeadline(stallDeadline, parentDL, hasParent)
@@ -1243,6 +1456,12 @@ func (c *NNTPConnection) readerLoop() {
 				return parentDL, hasParent, 0, nil
 			}
 		})
+		if err == nil && req.ValidateBody {
+			err = decoder.validateBody()
+		}
+		if err != nil && req.Ctx.Err() != nil {
+			err = req.Ctx.Err()
+		}
 		if err != nil {
 			if c.providerName != "" {
 				resp.Err = fmt.Errorf("%s: %w", c.providerName, err)
@@ -1255,6 +1474,7 @@ func (c *NNTPConnection) readerLoop() {
 		resp.Status = decoder.Message
 		resp.Lines = decoder.Lines
 		resp.Meta = decoder
+		resp.ProviderID = c.providerID
 
 		// Two-phase POST: coordinate with writeLoop via postReadyCh.
 		if req.PostMode {
@@ -1315,12 +1535,13 @@ func (c *NNTPConnection) readerLoop() {
 				if fb.IsZero() {
 					fb = respStart
 				}
-				if sentAt := req.sentAt.Load(); sentAt != 0 {
-					recordTTFB(c.stats, fb.Sub(time.Unix(0, sentAt)))
+				if headAt := req.responseHeadAt.Load(); headAt != 0 {
+					recordTTFB(c.stats, fb.Sub(time.Unix(0, headAt)))
 				}
 				recordSpeed(c.stats, n, time.Since(fb))
 			}
 		}
+		resp.Attempts = []AttemptEvidence{buildAttemptEvidence(req, c.providerID, resp, time.Now())}
 
 		if deliver {
 			// Best effort: don't block forever if the receiver abandoned the channel.
@@ -1333,6 +1554,7 @@ func (c *NNTPConnection) readerLoop() {
 
 		// release inflight slot (and the body slot, if this request took one)
 		<-c.inflightSem
+		c.releaseRequestPending(req)
 		if req.heldBody {
 			<-c.bodySem
 		}
@@ -1364,6 +1586,12 @@ func (c *NNTPConnection) readerLoop() {
 		// 502 "service unavailable" mid-session: close the connection so
 		// all pending requests fail fast instead of waiting in the pipeline.
 		if decoder.StatusCode == 502 {
+			_ = c.conn.Close()
+			c.failOutstanding()
+			return
+		}
+		// A 451 retry must use a fresh transport.
+		if decoder.StatusCode == 451 {
 			_ = c.conn.Close()
 			c.failOutstanding()
 			return
@@ -1430,24 +1658,29 @@ func WithSpeedAwareDispatch(enabled bool) ClientOption {
 
 // Provider describes a single NNTP server with its own credentials and connection count.
 type Provider struct {
-	Host            string
-	TLSConfig       *tls.Config
-	Auth            Auth
-	Connections     int
-	Inflight        int           // 0 defaults to 1; max concurrent BODY (and other body-bearing) commands per connection
-	StatInflight    int           // 0 defaults to Inflight; deeper pipeline depth for bodyless STAT commands. Because STAT carries no payload, many can be in flight per connection at negligible memory cost, amortising round-trips. Set higher than Inflight (e.g. 50-100) for STAT-heavy workloads without inflating BODY memory.
-	Factory         ConnFactory   // overrides Host/TLSConfig when set
-	Backup          bool          // if true, only used when main providers return 430
-	SkipPing        bool          // if true, skip the DATE ping on startup (for providers that don't support DATE)
-	IdleTimeout     time.Duration // 0 means no idle disconnect
-	ThrottleRestore time.Duration // 0 defaults to 30s
-	KeepAlive       time.Duration // TCP keep-alive interval; 0 defaults to 30s; negative disables
-	ReconnectDelay  time.Duration // 0 disables auto-reconnect after 502; when set, re-adds provider after this delay
+	// ID is the caller's stable transport identity for result and attempt
+	// evidence. When empty, the existing resolved provider name is used.
+	ID                     string
+	Host                   string
+	TLSConfig              *tls.Config
+	Auth                   Auth
+	Connections            int
+	Inflight               int           // 0 defaults to 1; max concurrent BODY (and other body-bearing) commands per connection
+	StatInflight           int           // 0 defaults to Inflight; deeper pipeline depth for bodyless STAT commands. Because STAT carries no payload, many can be in flight per connection at negligible memory cost, amortising round-trips. Set higher than Inflight (e.g. 50-100) for STAT-heavy workloads without inflating BODY memory.
+	BackgroundStatInflight int           // 0 defaults to StatInflight; max ordinary (non-priority) STAT commands written per connection
+	PriorityHeadroom       int           // pipeline slots per connection ordinary STAT cannot consume
+	Factory                ConnFactory   // overrides Host/TLSConfig when set
+	Backup                 bool          // if true, used only after all eligible main providers fail the request
+	SkipPing               bool          // if true, skip the DATE ping on startup (for providers that don't support DATE)
+	IdleTimeout            time.Duration // 0 means no idle disconnect
+	ThrottleRestore        time.Duration // 0 defaults to 30s
+	KeepAlive              time.Duration // TCP keep-alive interval; 0 defaults to 30s; negative disables
+	ReconnectDelay         time.Duration // 0 disables auto-reconnect after 502; when set, re-adds provider after this delay
 
-	// AttemptTimeout bounds dispatch plus time-to-first-response-byte for each
-	// attempt against this provider (it does NOT bound the body transfer, which
-	// is governed by StallTimeout). 0 selects an adaptive value derived from the
-	// provider's measured RTT, clamped to [2s, 10s]. Set explicitly to override.
+	// AttemptTimeout bounds time-to-first-response-byte starting only when the
+	// request becomes response head on its NNTP connection. Pool admission and
+	// pipeline wait remain governed by the caller context; body progress after
+	// the first byte is governed by StallTimeout. Zero selects an adaptive value.
 	AttemptTimeout time.Duration
 
 	// StallTimeout is the rolling progress deadline for a body transfer: once
@@ -1502,6 +1735,7 @@ type Provider struct {
 
 type providerGroup struct {
 	name      string
+	id        string
 	host      string // raw Provider.Host; empty for Factory-based providers
 	maxConns  int
 	ctx       context.Context // cancelled on removal/close
@@ -1520,8 +1754,8 @@ type providerGroup struct {
 	quotaResetAt atomic.Int64  // Unix nanoseconds of next reset; 0 = never
 }
 
-// attemptTimeout returns the per-attempt timeout (dispatch + time-to-first-byte
-// bound). An explicit Provider.AttemptTimeout wins; otherwise it adapts to the
+// attemptTimeout returns the response-head time-to-first-byte bound. An
+// explicit Provider.AttemptTimeout wins; otherwise it adapts to the
 // provider's observed time-to-first-byte EWMA (seeded from the ping RTT) as
 // 4×TTFB, clamped to [minAttemptTimeout, maxAttemptTimeout]. With no sample yet
 // it falls back to minAttemptTimeout, preserving the historical 2s behavior.
@@ -1682,6 +1916,13 @@ func resolveProviderName(p Provider, index int) string {
 	return fmt.Sprintf("provider-%d", index)
 }
 
+func resolveProviderID(p Provider, index int) string {
+	if p.ID != "" {
+		return p.ID
+	}
+	return resolveProviderName(p, index)
+}
+
 // startProviderGroup creates a providerGroup, pings the provider, and launches
 // connection slot goroutines. The caller is responsible for storing the group.
 func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
@@ -1696,6 +1937,15 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 	if statInflight < inflight {
 		statInflight = inflight
 	}
+	priorityHeadroom := max(p.PriorityHeadroom, 0)
+	if priorityHeadroom >= statInflight {
+		priorityHeadroom = statInflight - 1
+	}
+	backgroundStatInflight := p.BackgroundStatInflight
+	if backgroundStatInflight <= 0 {
+		backgroundStatInflight = statInflight
+	}
+	backgroundStatInflight = min(backgroundStatInflight, statInflight-priorityHeadroom)
 
 	factory := p.Factory
 	if factory == nil {
@@ -1713,6 +1963,7 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 
 	g := &providerGroup{
 		name:        name,
+		id:          resolveProviderID(p, index),
 		host:        p.Host,
 		maxConns:    p.Connections,
 		ctx:         gctx,
@@ -1726,6 +1977,9 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 		quotaPeriod: p.QuotaPeriod,
 	}
 	g.stats.quotaBytes = p.QuotaBytes
+	g.stats.pipelineLimit = statInflight * p.Connections
+	g.stats.backgroundStatLimit = backgroundStatInflight * p.Connections
+	g.stats.priorityHeadroom = priorityHeadroom * p.Connections
 	if p.QuotaBytes > 0 {
 		if p.QuotaUsed > 0 {
 			g.stats.quotaUsed.Store(p.QuotaUsed)
@@ -1786,7 +2040,7 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 
 	for range p.Connections {
 		c.wg.Add(1)
-		go runConnSlot(gctx, g.reqCh, g.prioCh, g.hotReqCh, g.hotPrioCh, factory, inflight, statInflight, p.Auth, p.UserAgent, p.IdleTimeout, stall, drainBytes, drainTimeout, kaInterval, kaCmd, gate, &g.stats, name, &c.wg)
+		go runConnSlot(gctx, g.reqCh, g.prioCh, g.hotReqCh, g.hotPrioCh, factory, inflight, statInflight, backgroundStatInflight, p.Auth, p.UserAgent, p.IdleTimeout, stall, drainBytes, drainTimeout, kaInterval, kaCmd, gate, &g.stats, name, g.id, &c.wg)
 	}
 
 	return g
@@ -1811,6 +2065,7 @@ func NewClient(ctx context.Context, providers []Provider, opts ...ClientOption) 
 
 	// Validation only — no TCP connections are created here.
 	seen := make(map[string]struct{}, len(providers))
+	seenIDs := make(map[string]struct{}, len(providers))
 	for i, p := range providers {
 		if p.Connections <= 0 {
 			return nil, fmt.Errorf("nntp: provider connections must be > 0")
@@ -1823,6 +2078,11 @@ func NewClient(ctx context.Context, providers []Provider, opts ...ClientOption) 
 			return nil, fmt.Errorf("nntp: provider %q already exists", name)
 		}
 		seen[name] = struct{}{}
+		id := resolveProviderID(p, i)
+		if _, dup := seenIDs[id]; dup {
+			return nil, fmt.Errorf("nntp: provider ID %q already exists", id)
+		}
+		seenIDs[id] = struct{}{}
 	}
 
 	if ctx == nil {
@@ -1905,7 +2165,16 @@ func (c *Client) SendPriority(ctx context.Context, payload []byte, bodyWriter io
 		metaFn = onMeta[0]
 	}
 
-	go c.doSendWithRetry(ctx, payload, bodyWriter, metaFn, respCh, true)
+	go c.doSendWithRetry(ctx, payload, bodyWriter, metaFn, respCh, true, false)
+	return respCh
+}
+
+func (c *Client) sendValidatedBody(ctx context.Context, payload []byte, bodyWriter io.Writer, onMeta func(YEncMeta), priority bool) <-chan Response {
+	respCh := make(chan Response, 1)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	go c.doSendWithRetry(ctx, payload, bodyWriter, onMeta, respCh, priority, true)
 	return respCh
 }
 
@@ -1939,6 +2208,7 @@ func extractProbeMsgID(payload []byte) []byte {
 
 // probeResult carries the outcome of one parallel STAT probe.
 type probeResult struct {
+	index     int
 	g         *providerGroup
 	resp      Response
 	ok        bool
@@ -1957,6 +2227,8 @@ func (c *Client) raceCandidates(
 	statPayload, payload []byte,
 	bodyWriter io.Writer,
 	onMeta func(YEncMeta),
+	validateBody bool,
+	attempts *[]AttemptEvidence,
 	skipHosts *[4]string,
 	skipCount *int,
 	respCh chan<- Response,
@@ -1970,6 +2242,7 @@ func (c *Client) raceCandidates(
 		}
 		if g.isQuotaExceeded() {
 			lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
+			*attempts = append(*attempts, buildEligibilityEvidence(payload, g.id, lastErr, validateBody))
 			continue
 		}
 		if g.host != "" && seen[g.host] {
@@ -1988,7 +2261,8 @@ func (c *Client) raceCandidates(
 	// Single live candidate: skip the probe RTT and send the real payload directly.
 	if len(live) == 1 {
 		g := live[0]
-		resp, ok, done := c.tryGroup(ctx, g, payload, bodyWriter, onMeta, true)
+		resp, ok, done := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, true, validateBody, false)
+		*attempts = append(*attempts, resp.Attempts...)
 		if done {
 			return false, true, lastErr
 		}
@@ -2013,24 +2287,30 @@ func (c *Client) raceCandidates(
 			c.nextIdx.Add(1)
 			return false, false, lastErr
 		}
+		resp.Attempts = cloneAttempts(*attempts)
 		respCh <- resp
 		return true, false, lastErr
 	}
 
 	// ≥2 candidates: probe all in parallel.
 	results := make(chan probeResult, len(live))
-	for _, g := range live {
-		go func(g *providerGroup) {
-			resp, ok, done := c.tryGroup(ctx, g, statPayload, nil, nil, true)
-			results <- probeResult{g: g, resp: resp, ok: ok, cancelled: done}
-		}(g)
+	for index, g := range live {
+		go func(index int, g *providerGroup) {
+			resp, ok, done := c.tryGroupResilient(ctx, g, statPayload, nil, nil, true, false, false)
+			results <- probeResult{index: index, g: g, resp: resp, ok: ok, cancelled: done}
+		}(index, g)
 	}
 
 	// Collect ALL probe results before acting on the winner, so that side
 	// effects like 502 provider removal are applied regardless of order.
-	var winner *providerGroup
+	ordered := make([]probeResult, len(live))
 	for range live {
 		pr := <-results
+		ordered[pr.index] = pr
+	}
+	var winners []*providerGroup
+	for _, pr := range ordered {
+		*attempts = append(*attempts, pr.resp.Attempts...)
 		if pr.cancelled {
 			cancelled = true
 			continue
@@ -2057,11 +2337,9 @@ func (c *Client) raceCandidates(
 			}
 			c.nextIdx.Add(1)
 		case 223:
-			if winner == nil {
-				winner = g // first 223; keep collecting for 502s
-			}
+			winners = append(winners, g)
 		default:
-			lastErr = fmt.Errorf("%s: unexpected STAT probe status %d", g.name, pr.resp.StatusCode)
+			lastErr = fmt.Errorf("%s: %w", g.name, toError(pr.resp.StatusCode, pr.resp.Status))
 		}
 	}
 
@@ -2069,46 +2347,55 @@ func (c *Client) raceCandidates(
 		return false, true, lastErr
 	}
 
-	if winner == nil {
+	if len(winners) == 0 {
 		return false, false, lastErr
 	}
 
-	// Send the real payload to the winner on the priority lane.
-	resp, ok, done := c.tryGroup(ctx, winner, payload, bodyWriter, onMeta, true)
-	if done {
-		return false, true, lastErr
-	}
-	if !ok {
-		return false, false, lastErr
-	}
-	if resp.Err != nil {
-		// A committed attempt with a caller writer already streamed partial
-		// bytes; deliver the error rather than letting the caller re-stream
-		// into the same writer on another provider.
-		if bodyWriter != nil && attemptCommittedResp(resp) {
-			respCh <- resp
-			return true, false, nil
+	// Try STAT-positive providers in configured order. A faster later probe may
+	// not override the preferred provider, and corrupt/expired winners advance.
+	for _, winner := range winners {
+		resp, ok, done := c.tryGroupResilient(ctx, winner, payload, bodyWriter, onMeta, true, validateBody, false)
+		*attempts = append(*attempts, resp.Attempts...)
+		if done {
+			return false, true, lastErr
 		}
-		return false, false, resp.Err
-	}
-	if resp.StatusCode == 430 || resp.StatusCode == 423 {
-		// Rare: article expired between STAT and BODY.
-		if winner.host != "" && *skipCount < len(skipHosts) {
-			skipHosts[*skipCount] = winner.host
-			*skipCount++
+		if !ok {
+			continue
 		}
-		c.nextIdx.Add(1)
-		return false, false, lastErr
-	}
-	if resp.StatusCode == 502 {
-		_ = c.RemoveProvider(winner.name)
-		if winner.p.ReconnectDelay > 0 {
-			c.scheduleReconnect(winner)
+		if resp.Err != nil {
+			if bodyWriter != nil && attemptCommittedResp(resp) {
+				resp.Attempts = cloneAttempts(*attempts)
+				respCh <- resp
+				return true, false, nil
+			}
+			lastErr = resp.Err
+			continue
 		}
-		return false, false, fmt.Errorf("%s: %w", winner.name, ErrServiceUnavailable)
+		if resp.StatusCode == 430 || resp.StatusCode == 423 {
+			if winner.host != "" && *skipCount < len(skipHosts) {
+				skipHosts[*skipCount] = winner.host
+				*skipCount++
+			}
+			c.nextIdx.Add(1)
+			continue
+		}
+		if resp.StatusCode == 502 {
+			_ = c.RemoveProvider(winner.name)
+			if winner.p.ReconnectDelay > 0 {
+				c.scheduleReconnect(winner)
+			}
+			lastErr = fmt.Errorf("%s: %w", winner.name, ErrServiceUnavailable)
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+			lastErr = fmt.Errorf("%s: %w", winner.name, toError(resp.StatusCode, resp.Status))
+			continue
+		}
+		resp.Attempts = cloneAttempts(*attempts)
+		respCh <- resp
+		return true, false, lastErr
 	}
-	respCh <- resp
-	return true, false, lastErr
+	return false, false, lastErr
 }
 
 // minDeadline returns d, unless other is an earlier deadline (when hasOther),
@@ -2120,27 +2407,18 @@ func minDeadline(d, other time.Time, hasOther bool) (time.Time, bool) {
 	return d, true
 }
 
-// writeDeadline is the deadline used while writing the request payload: the
-// earlier of the caller's ctx deadline and the attempt deadline, so a dead
-// socket cannot hang the writer. Payloads are tiny, so the attempt deadline is
-// a safe upper bound.
+// writeDeadline keeps the caller's end-to-end deadline active during writes.
+// Provider response timing begins later, at response-head admission.
 func (req *Request) writeDeadline() (time.Time, bool) {
-	dl, ok := req.Ctx.Deadline()
-	if !req.attemptDeadline.IsZero() && (!ok || req.attemptDeadline.Before(dl)) {
-		return req.attemptDeadline, true
-	}
-	return dl, ok
+	return req.Ctx.Deadline()
 }
 
 // tryGroup dispatches a single request to a provider group and waits for the
 // response. priority=true routes through the priority channels.
 //
-// The attempt timeout bounds only dispatch + time-to-first-response-byte, not
-// the whole body transfer: the request ctx carries no fixed deadline, and a
-// timer races the response. If the timer fires before any byte arrives the
-// attempt is abandoned (CAS pending→abandoned) and we fail over; if the reader
-// committed first (it saw a byte) we keep waiting for the body to finish, since
-// failing over after partial delivery would corrupt a caller's writer.
+// The caller context governs pool admission and pipeline wait. The separate
+// provider response timeout begins in readerLoop only at FIFO response-head
+// admission, so local queueing cannot be classified as provider latency.
 func (c *Client) tryGroup(
 	ctx context.Context,
 	g *providerGroup,
@@ -2148,23 +2426,30 @@ func (c *Client) tryGroup(
 	bodyWriter io.Writer,
 	onMeta func(YEncMeta),
 	priority bool,
+	validateBody bool,
+	freshTransport bool,
 ) (resp Response, ok bool, done bool) {
 	reqCtx, reqCancel := context.WithCancel(ctx)
 	defer reqCancel()
 
-	attemptTimeout := g.attemptTimeout()
 	innerCh := make(chan Response, 1)
 	req := &Request{
 		Ctx:             reqCtx,
 		Payload:         payload,
 		RespCh:          innerCh,
 		BodyWriter:      bodyWriter,
+		ValidateBody:    validateBody,
+		FreshTransport:  freshTransport,
+		Priority:        priority,
 		OnMeta:          onMeta,
-		attemptDeadline: time.Now().Add(attemptTimeout),
+		submittedAt:     time.Now(),
+		responseTimeout: g.attemptTimeout(),
 	}
-
-	timer := time.NewTimer(attemptTimeout)
-	defer timer.Stop()
+	failAttempt := func(cause error) Response {
+		response := Response{Err: cause, Request: req, ProviderID: g.id}
+		response.Attempts = []AttemptEvidence{buildAttemptEvidence(req, g.id, response, time.Now())}
+		return response
+	}
 
 	var hotCh chan *Request
 	var coldCh chan *Request
@@ -2181,15 +2466,11 @@ func (c *Client) tryGroup(
 	default:
 		select {
 		case <-c.ctx.Done():
-			return Response{}, false, true
+			return failAttempt(c.ctx.Err()), false, true
 		case <-reqCtx.Done():
-			return Response{}, false, ctx.Err() != nil
+			return failAttempt(reqCtx.Err()), false, ctx.Err() != nil
 		case <-g.ctx.Done():
-			return Response{}, false, false
-		case <-timer.C:
-			// Could not be dispatched within the attempt window: the provider
-			// is saturated. Fail over.
-			return Response{}, false, false
+			return failAttempt(ErrConnectionDied), false, false
 		case coldCh <- req:
 		}
 	}
@@ -2197,25 +2478,18 @@ func (c *Client) tryGroup(
 	for {
 		select {
 		case resp, ok = <-innerCh:
+			if ok && len(resp.Attempts) == 0 && !errors.Is(resp.Err, errFreshTransportRequired) {
+				resp.Request = req
+				resp.ProviderID = g.id
+				resp.Attempts = []AttemptEvidence{buildAttemptEvidence(req, g.id, resp, time.Now())}
+			}
 			return resp, ok, false
 		case <-c.ctx.Done():
-			return Response{}, false, true
+			return failAttempt(c.ctx.Err()), false, true
 		case <-g.ctx.Done():
-			return Response{}, false, false
+			return failAttempt(ErrConnectionDied), false, false
 		case <-reqCtx.Done():
-			return Response{}, false, ctx.Err() != nil
-		case <-timer.C:
-			if req.attemptState.CompareAndSwap(attemptPending, attemptAbandoned) {
-				// No response byte arrived in time: hung or too-slow to start.
-				// Cancel so the reader drops the request, and fail over.
-				reqCancel()
-				// done only when the caller's or the pool's context was
-				// cancelled (true shutdown), not on a plain attempt timeout.
-				return Response{}, false, ctx.Err() != nil || c.ctx.Err() != nil
-			}
-			// Reader already committed (first byte arrived): the body is
-			// streaming. Do not fail over; keep waiting for it to finish. The
-			// timer has fired and will not fire again.
+			return failAttempt(reqCtx.Err()), false, ctx.Err() != nil
 		}
 	}
 }
@@ -2239,6 +2513,71 @@ func hostSkipped(host string, skipHosts *[4]string, count int) bool {
 // must not be retried or failed over when a caller-supplied writer is in use.
 func attemptCommittedResp(resp Response) bool {
 	return resp.Request != nil && resp.Request.decodedCommitted.Load()
+}
+
+func buildAttemptEvidence(req *Request, providerID string, resp Response, completedAt time.Time) AttemptEvidence {
+	cause := resp.Err
+	if cause == nil {
+		cause = toError(resp.StatusCode, resp.Status)
+	}
+	outcome := classifyOutcome(resp.StatusCode, cause)
+	validation := BodyValidationNotApplicable
+	if operationFromPayload(req.Payload) == OperationBody {
+		if !req.ValidateBody {
+			validation = BodyValidationNotRequested
+		} else {
+			switch outcome {
+			case OutcomeSuccess:
+				validation = BodyValidationValid
+			case OutcomeCorruptBody:
+				validation = BodyValidationInvalid
+			default:
+				if resp.StatusCode == nntpBody || resp.Err != nil {
+					validation = BodyValidationIncomplete
+				}
+			}
+		}
+	}
+
+	var poolQueue, headWait, service time.Duration
+	writtenAt := req.writtenAt.Load()
+	headAt := req.responseHeadAt.Load()
+	if !req.submittedAt.IsZero() && writtenAt > 0 {
+		poolQueue = time.Unix(0, writtenAt).Sub(req.submittedAt)
+	} else if !req.submittedAt.IsZero() {
+		poolQueue = completedAt.Sub(req.submittedAt)
+	}
+	if writtenAt > 0 && headAt > 0 {
+		headWait = time.Duration(headAt - writtenAt)
+	} else if writtenAt > 0 {
+		headWait = completedAt.Sub(time.Unix(0, writtenAt))
+	}
+	if headAt > 0 {
+		service = completedAt.Sub(time.Unix(0, headAt))
+	}
+
+	providerResponseTimeout := false
+	var networkError net.Error
+	if headAt > 0 && req.Ctx.Err() == nil && errors.As(resp.Err, &networkError) && networkError.Timeout() {
+		providerResponseTimeout = true
+	}
+	return AttemptEvidence{
+		ProviderID:               providerID,
+		Operation:                operationFromPayload(req.Payload),
+		Outcome:                  outcome,
+		ResponseCode:             resp.StatusCode,
+		BodyValidation:           validation,
+		Cause:                    cause,
+		ProviderResponseTimeout:  providerResponseTimeout,
+		PoolQueueDuration:        max(poolQueue, 0),
+		PipelineHeadWaitDuration: max(headWait, 0),
+		ResponseServiceDuration:  max(service, 0),
+	}
+}
+
+func buildEligibilityEvidence(payload []byte, providerID string, cause error, validateBody bool) AttemptEvidence {
+	req := &Request{Payload: payload, ValidateBody: validateBody}
+	return buildAttemptEvidence(req, providerID, Response{Err: cause}, time.Now())
 }
 
 // maxSpeedScore is the highest multiplier speed-aware dispatch applies to a
@@ -2293,7 +2632,7 @@ func speedScore(speed, maxSpeed float64) int {
 }
 
 func (c *Client) sendWithRetry(ctx context.Context, payload []byte, bodyWriter io.Writer, onMeta func(YEncMeta), respCh chan Response) {
-	c.doSendWithRetry(ctx, payload, bodyWriter, onMeta, respCh, false)
+	c.doSendWithRetry(ctx, payload, bodyWriter, onMeta, respCh, false, false)
 }
 
 // tryGroupResilient retries a single provider on a fresh connection when a
@@ -2311,10 +2650,17 @@ func (c *Client) tryGroupResilient(
 	bodyWriter io.Writer,
 	onMeta func(YEncMeta),
 	priority bool,
+	validateBody bool,
+	freshTransport bool,
 ) (resp Response, ok bool, cancelled bool) {
-	for r := 0; ; r++ {
-		resp, ok, cancelled = c.tryGroup(ctx, g, payload, bodyWriter, onMeta, priority)
+	var attempts []AttemptEvidence
+	connRetries := 0
+	temporaryRetried := false
+	for {
+		resp, ok, cancelled = c.tryGroup(ctx, g, payload, bodyWriter, onMeta, priority, validateBody, freshTransport)
+		attempts = append(attempts, resp.Attempts...)
 		if cancelled || !ok {
+			resp.Attempts = cloneAttempts(attempts)
 			return
 		}
 		// If the attempt already streamed bytes into the caller's writer, never
@@ -2322,16 +2668,33 @@ func (c *Client) tryGroupResilient(
 		// Buffered requests (bodyWriter == nil) keep their per-attempt buffer,
 		// so retrying them stays safe.
 		if bodyWriter != nil && attemptCommittedResp(resp) {
+			resp.Attempts = cloneAttempts(attempts)
 			return
 		}
-		if r < maxConnDiedRetries && isConnectionDeathError(resp.Err) {
+		if errors.Is(resp.Err, errFreshTransportRequired) {
+			continue
+		}
+		if !temporaryRetried && resp.Err == nil && resp.StatusCode == 451 {
+			temporaryRetried = true
+			delay := temporaryRetryMinDelay + time.Duration(rand.Int64N(int64(temporaryRetryJitter)+1))
+			select {
+			case <-time.After(delay):
+				continue
+			case <-ctx.Done():
+				resp.Attempts = cloneAttempts(attempts)
+				return resp, true, true
+			}
+		}
+		if connRetries < maxConnDiedRetries && isConnectionDeathError(resp.Err) {
+			connRetries++
 			continue // dead connection drained; retry fresh on same provider
 		}
+		resp.Attempts = cloneAttempts(attempts)
 		return
 	}
 }
 
-func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter io.Writer, onMeta func(YEncMeta), respCh chan Response, priority bool) {
+func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter io.Writer, onMeta func(YEncMeta), respCh chan Response, priority bool, validateBody bool) {
 	defer close(respCh)
 
 	// Precompute for STAT probe: extract message-ID once.
@@ -2345,6 +2708,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 	var lastResp Response
 	hasResp := false
 	var lastErr error
+	var attempts []AttemptEvidence
 	post430 := false
 
 	// Track hosts that returned 430 so we can skip other providers on
@@ -2394,15 +2758,17 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 		}
 		if g.isQuotaExceeded() {
 			lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
+			attempts = append(attempts, buildEligibilityEvidence(payload, g.id, lastErr, validateBody))
 			continue
 		}
-		resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430)
+		resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430, validateBody, false)
+		attempts = append(attempts, resp.Attempts...)
 		if cancelled {
 			err := ctx.Err()
 			if err == nil {
 				err = c.ctx.Err()
 			}
-			respCh <- Response{Err: err}
+			respCh <- cancellationResponse(attempts, err)
 			return
 		}
 		if !ok {
@@ -2414,6 +2780,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			// bytes; deliver the error rather than re-streaming into the same
 			// writer on another provider.
 			if bodyWriter != nil && attemptCommittedResp(resp) {
+				resp.Attempts = cloneAttempts(attempts)
 				respCh <- resp
 				return
 			}
@@ -2430,7 +2797,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			lastErr = fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
 			continue
 		}
-		if resp.StatusCode == 430 {
+		if resp.StatusCode == 430 || resp.StatusCode == 423 {
 			c.nextIdx.Add(1) // bias next request away from this provider
 			if g.host != "" && skipCount < len(skipHosts) {
 				skipHosts[skipCount] = g.host
@@ -2448,14 +2815,14 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 				}
 				delivered, cancelled, raceErr := c.raceCandidates(
 					ctx, rest, statPayload, payload, bodyWriter, onMeta,
-					&skipHosts, &skipCount, respCh,
+					validateBody, &attempts, &skipHosts, &skipCount, respCh,
 				)
 				if cancelled {
 					err := ctx.Err()
 					if err == nil {
 						err = c.ctx.Err()
 					}
-					respCh <- Response{Err: err}
+					respCh <- cancellationResponse(attempts, err)
 					return
 				}
 				if delivered {
@@ -2468,7 +2835,12 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			}
 			continue
 		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+			lastErr = fmt.Errorf("%s: %w", g.name, toError(resp.StatusCode, resp.Status))
+			continue
+		}
 		// Success.
+		resp.Attempts = cloneAttempts(attempts)
 		respCh <- resp
 		return
 	}
@@ -2478,14 +2850,14 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 	if raceable && post430 {
 		delivered, cancelled, raceErr := c.raceCandidates(
 			ctx, backups, statPayload, payload, bodyWriter, onMeta,
-			&skipHosts, &skipCount, respCh,
+			validateBody, &attempts, &skipHosts, &skipCount, respCh,
 		)
 		if cancelled {
 			err := ctx.Err()
 			if err == nil {
 				err = c.ctx.Err()
 			}
-			respCh <- Response{Err: err}
+			respCh <- cancellationResponse(attempts, err)
 			return
 		}
 		if delivered {
@@ -2502,15 +2874,17 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 			}
 			if g.isQuotaExceeded() {
 				lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
+				attempts = append(attempts, buildEligibilityEvidence(payload, g.id, lastErr, validateBody))
 				continue
 			}
-			resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430)
+			resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430, validateBody, false)
+			attempts = append(attempts, resp.Attempts...)
 			if cancelled {
 				err := ctx.Err()
 				if err == nil {
 					err = c.ctx.Err()
 				}
-				respCh <- Response{Err: err}
+				respCh <- cancellationResponse(attempts, err)
 				return
 			}
 			if !ok {
@@ -2521,6 +2895,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 				// partial bytes; deliver the error rather than re-streaming into
 				// the same writer on another provider.
 				if bodyWriter != nil && attemptCommittedResp(resp) {
+					resp.Attempts = cloneAttempts(attempts)
 					respCh <- resp
 					return
 				}
@@ -2535,17 +2910,30 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 				lastErr = fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
 				continue
 			}
-			// Deliver whatever backup returns (including 430).
+			resp.Attempts = cloneAttempts(attempts)
+			if resp.StatusCode == 430 || resp.StatusCode == 423 {
+				lastResp = resp
+				hasResp = true
+				continue
+			}
+			if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+				lastErr = fmt.Errorf("%s: %w", g.name, toError(resp.StatusCode, resp.Status))
+				continue
+			}
 			respCh <- resp
 			return
 		}
 	}
 
 	// 3. All providers exhausted — deliver the last 430, the last error, or a fallback.
-	if hasResp {
+	if lastErr != nil {
+		respCh <- Response{
+			Err:      newTransportError(attempts, lastErr),
+			Attempts: cloneAttempts(attempts),
+		}
+	} else if hasResp {
+		lastResp.Attempts = cloneAttempts(attempts)
 		respCh <- lastResp
-	} else if lastErr != nil {
-		respCh <- Response{Err: fmt.Errorf("nntp: all providers exhausted: %w", lastErr)}
 	} else {
 		respCh <- Response{Err: errors.New("nntp: all providers exhausted")}
 	}
@@ -2570,19 +2958,25 @@ func (c *Client) Stats() ClientStats {
 			maxSlots, running := g.gate.snapshot()
 			quotaUsed := g.stats.quotaUsed.Load()
 			ps := ProviderStats{
-				Name:              g.name,
-				SpeedEWMA:         speedEWMABytesPerSec(&g.stats),
-				BytesConsumed:     consumed,
-				Missing:           g.stats.Missing.Load(),
-				Errors:            g.stats.Errors.Load(),
-				ActiveConnections: running,
-				MaxConnections:    maxSlots,
-				AvailableSlots:    int(g.gate.available.Load()),
-				TTFB:              time.Duration(g.stats.ttfbEWMA.Load()),
-				Ping:              g.stats.Ping,
-				QuotaBytes:        g.stats.quotaBytes,
-				QuotaUsed:         quotaUsed,
-				QuotaExceeded:     g.stats.quotaBytes > 0 && quotaUsed >= g.stats.quotaBytes,
+				Name:                g.name,
+				ProviderID:          g.id,
+				SpeedEWMA:           speedEWMABytesPerSec(&g.stats),
+				BytesConsumed:       consumed,
+				Missing:             g.stats.Missing.Load(),
+				Errors:              g.stats.Errors.Load(),
+				ActiveConnections:   running,
+				MaxConnections:      maxSlots,
+				AvailableSlots:      int(g.gate.available.Load()),
+				TTFB:                time.Duration(g.stats.ttfbEWMA.Load()),
+				PipelineInUse:       int(g.stats.PipelineInUse.Load()),
+				PipelineLimit:       g.stats.pipelineLimit,
+				BackgroundStatInUse: int(g.stats.BackgroundStatInUse.Load()),
+				BackgroundStatLimit: g.stats.backgroundStatLimit,
+				PriorityHeadroom:    g.stats.priorityHeadroom,
+				Ping:                g.stats.Ping,
+				QuotaBytes:          g.stats.quotaBytes,
+				QuotaUsed:           quotaUsed,
+				QuotaExceeded:       g.stats.quotaBytes > 0 && quotaUsed >= g.stats.quotaBytes,
 			}
 			if g.stats.quotaBytes > 0 && g.quotaPeriod > 0 {
 				resetAt := g.quotaResetAt.Load()
@@ -2615,11 +3009,12 @@ func (c *Client) AddProvider(p Provider) error {
 
 	idx := int(c.providerIdx.Add(1))
 	name := resolveProviderName(p, idx)
+	id := resolveProviderID(p, idx)
 
 	// Check for duplicate name.
 	for _, gs := range [...]*[]*providerGroup{c.mainGroups.Load(), c.backupGroups.Load()} {
 		for _, g := range *gs {
-			if g.name == name {
+			if g.name == name || g.id == id {
 				return fmt.Errorf("nntp: provider %q already exists", name)
 			}
 		}

--- a/pr1_regression_test.go
+++ b/pr1_regression_test.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/mnightingale/rapidyenc"
 )
 
 const regressionBodySize = 2 * 1024 * 1024
@@ -134,7 +136,9 @@ func removeYEnd(response []byte) []byte {
 		panic("yEnc fixture contained an unterminated =yend")
 	}
 	end += start + 4
-	return append(truncated[:start], truncated[end:]...)
+	// Preserve the CRLF that terminates the encoded data so the NNTP dot line
+	// remains a valid article terminator after removing only the trailer line.
+	return append(truncated[:start+2], truncated[end:]...)
 }
 
 func TestPR1PrebufferedDecodedBytesCommitAttempt(t *testing.T) {
@@ -318,6 +322,179 @@ func TestPR1CancelledBodyDrainIsBounded(t *testing.T) {
 	}
 }
 
+func TestPR1CancelledPipelineDoesNotDelayNewPriorityBody(t *testing.T) {
+	const depth = 10
+	largeBody := yencSinglePart(bytes.Repeat([]byte("q"), regressionBodySize), "obsolete.bin")
+	priorityBody := yencSinglePart([]byte("priority payload"), "priority.bin")
+	firstCommandsRead := make(chan struct{})
+	var connections atomic.Int32
+	factory := func(context.Context) (net.Conn, error) {
+		connection := connections.Add(1)
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 regression server ready\r\n"))
+			reader := bufio.NewReader(server)
+			if connection == 1 {
+				for range depth {
+					if _, err := reader.ReadString('\n'); err != nil {
+						return
+					}
+				}
+				close(firstCommandsRead)
+				_, _ = server.Write(largeBody)
+				return
+			}
+			if _, err := reader.ReadString('\n'); err != nil {
+				return
+			}
+			_, _ = server.Write(priorityBody)
+		}()
+		return client, nil
+	}
+	client := newRegressionClient(t, Provider{
+		Host:                      "cancel-priority.invalid:119",
+		Factory:                   factory,
+		Connections:               1,
+		Inflight:                  depth,
+		StatInflight:              depth,
+		SkipPing:                  true,
+		AbandonedBodyDrainBytes:   64 * 1024,
+		AbandonedBodyDrainTimeout: 100 * time.Millisecond,
+	})
+	cancels := make([]context.CancelFunc, 0, depth)
+	for index := range depth {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancels = append(cancels, cancel)
+		_ = client.Send(ctx, []byte("BODY <obsolete-"+string(rune('a'+index))+"@example.invalid>\r\n"), io.Discard)
+	}
+	select {
+	case <-firstCommandsRead:
+	case <-time.After(2 * time.Second):
+		t.Fatal("obsolete BODY pipeline did not fill")
+	}
+	for _, cancel := range cancels {
+		cancel()
+	}
+	start := time.Now()
+	body, err := client.BodyPriority(context.Background(), "priority@example.invalid")
+	if err != nil {
+		t.Fatalf("priority Body() error = %v", err)
+	}
+	if !bytes.Equal(body.Bytes, []byte("priority payload")) {
+		t.Fatalf("priority Body() bytes = %q", body.Bytes)
+	}
+	if elapsed := time.Since(start); elapsed > 750*time.Millisecond {
+		t.Errorf("priority Body() waited %v behind canceled payload, want bounded recovery", elapsed)
+	}
+	if got := connections.Load(); got < 2 {
+		t.Errorf("connections = %d, want canceled pipeline socket retired", got)
+	}
+}
+
+func BenchmarkPR1AbandonedBodyDrainCaps(b *testing.B) {
+	body := yencSinglePart(bytes.Repeat([]byte("b"), regressionBodySize), "benchmark.bin")
+	cases := []struct {
+		name       string
+		byteCap    int
+		timeCap    time.Duration
+		writeDelay time.Duration
+	}{
+		{name: "bytes_64KiB", byteCap: 64 * 1024, timeCap: 2 * time.Second},
+		{name: "bytes_256KiB", byteCap: 256 * 1024, timeCap: 2 * time.Second},
+		{name: "bytes_1MiB", byteCap: 1024 * 1024, timeCap: 2 * time.Second},
+		{name: "time_50ms", byteCap: 8 * 1024 * 1024, timeCap: 50 * time.Millisecond, writeDelay: 10 * time.Millisecond},
+		{name: "time_100ms", byteCap: 8 * 1024 * 1024, timeCap: 100 * time.Millisecond, writeDelay: 10 * time.Millisecond},
+		{name: "time_250ms", byteCap: 8 * 1024 * 1024, timeCap: 250 * time.Millisecond, writeDelay: 10 * time.Millisecond},
+	}
+	for _, benchmark := range cases {
+		b.Run(benchmark.name, func(b *testing.B) {
+			var totalWritten int64
+			for range b.N {
+				clientConn, serverConn := net.Pipe()
+				firstChunkWritten := make(chan struct{})
+				writtenResult := make(chan int, 1)
+				go func() {
+					defer func() { _ = serverConn.Close() }()
+					_, _ = serverConn.Write([]byte("200 benchmark server ready\r\n"))
+					reader := bufio.NewReader(serverConn)
+					for range 10 {
+						if _, err := reader.ReadString('\n'); err != nil {
+							writtenResult <- 0
+							return
+						}
+					}
+					written := 0
+					signaled := false
+					for offset := 0; offset < len(body); {
+						end := min(offset+16*1024, len(body))
+						n, err := serverConn.Write(body[offset:end])
+						written += n
+						if !signaled && written > 0 {
+							close(firstChunkWritten)
+							signaled = true
+						}
+						offset += n
+						if err != nil {
+							writtenResult <- written
+							return
+						}
+						if benchmark.writeDelay > 0 {
+							time.Sleep(benchmark.writeDelay)
+						}
+					}
+					writtenResult <- written
+				}()
+
+				reqCh := make(chan *Request, 10)
+				nc, err := newNNTPConnectionFromConn(
+					context.Background(), clientConn, 10, reqCh, nil, Auth{}, "", nil, nil,
+				)
+				if err != nil {
+					b.Fatalf("newNNTPConnectionFromConn() error = %v", err)
+				}
+				nc.abandonedDrainBytes = benchmark.byteCap
+				nc.abandonedDrainTimeout = benchmark.timeCap
+				cancels := make([]context.CancelFunc, 0, 10)
+				for index := range 10 {
+					ctx, cancel := context.WithCancel(context.Background())
+					cancels = append(cancels, cancel)
+					reqCh <- &Request{
+						Ctx:        ctx,
+						Payload:    []byte("BODY <benchmark-" + string(rune('a'+index)) + "@example.invalid>\r\n"),
+						RespCh:     make(chan Response, 1),
+						BodyWriter: io.Discard,
+					}
+				}
+				go nc.Run()
+				<-firstChunkWritten
+				for _, cancel := range cancels {
+					cancel()
+				}
+				written := <-writtenResult
+				totalWritten += int64(written)
+				_ = nc.Close()
+			}
+			b.ReportMetric(float64(totalWritten)/float64(b.N), "drained_bytes/op")
+		})
+	}
+}
+
+func TestPR1RawSendPreservesUnvalidatedV4BodyBehavior(t *testing.T) {
+	provider := &regressionProvider{
+		host:    "raw-v4.invalid:119",
+		respond: func(_ int, _ string) []byte { return []byte("222 body follows\r\n.\r\n") },
+	}
+	client := newRegressionClient(t, provider.provider(false))
+	resp := <-client.Send(context.Background(), []byte("BODY <fixture@example.invalid>\r\n"), nil)
+	if resp.Err != nil || resp.StatusCode != 222 {
+		t.Fatalf("raw Send() response = %+v, want legacy unvalidated 222 success", resp)
+	}
+	if len(resp.Attempts) != 1 || resp.Attempts[0].BodyValidation != BodyValidationNotRequested {
+		t.Errorf("raw BODY attempts = %+v, want validation not requested", resp.Attempts)
+	}
+}
+
 func TestPR1ArticleAbsenceFallbackIncludes423(t *testing.T) {
 	valid := []byte("valid fallback payload")
 
@@ -394,6 +571,18 @@ func TestPR1451RetriesFreshThenFallsBack(t *testing.T) {
 	if second.commandCount("BODY") != 1 {
 		t.Errorf("backup BODY attempts = %d, want 1", second.commandCount("BODY"))
 	}
+	if len(body.Attempts) != 3 {
+		t.Fatalf("attempt count = %d, want 2 temporary attempts plus backup success", len(body.Attempts))
+	}
+	if body.Attempts[0].Outcome != OutcomeTemporaryFailure ||
+		body.Attempts[1].Outcome != OutcomeTemporaryFailure ||
+		body.Attempts[2].Outcome != OutcomeSuccess {
+		t.Errorf("attempt outcomes = %v, want temporary, temporary, success", []OutcomeKind{
+			body.Attempts[0].Outcome,
+			body.Attempts[1].Outcome,
+			body.Attempts[2].Outcome,
+		})
+	}
 }
 
 func TestPR1MixedAbsenceAndTemporaryIsInconclusive(t *testing.T) {
@@ -426,8 +615,45 @@ func TestPR1MixedAbsenceAndTemporaryIsInconclusive(t *testing.T) {
 	if errors.Is(err, ErrArticleNotFound) {
 		t.Fatalf("Body() error = %v, mixed absence and temporary must not be hard absence", err)
 	}
+	var transportErr *TransportError
+	if !errors.As(err, &transportErr) || transportErr.Kind != OutcomeInconclusive {
+		t.Fatalf("Body() error = %v, want structured inconclusive mixed outcome", err)
+	}
 	if second.commandCount("STAT") == 0 || third.commandCount("STAT") == 0 {
 		t.Fatalf("parallel probe commands: temporary=%d missing=%d, want both attempted", second.commandCount("STAT"), third.commandCount("STAT"))
+	}
+}
+
+func TestPR1UnavailableEligibilityDoesNotCollapseToHardAbsence(t *testing.T) {
+	missing := &regressionProvider{
+		host:    "quota-missing.invalid:119",
+		respond: func(_ int, _ string) []byte { return []byte("430 no such article\r\n") },
+	}
+	unavailable := &regressionProvider{
+		host: "quota-unavailable.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return yencSinglePart([]byte("must not be requested"), "quota.bin")
+		},
+	}
+	unavailableConfig := unavailable.provider(false)
+	unavailableConfig.QuotaBytes = 1
+	unavailableConfig.QuotaUsed = 1
+	client := newRegressionClient(t, missing.provider(false), unavailableConfig)
+	_, err := client.Body(context.Background(), "fixture@example.invalid")
+	var transportErr *TransportError
+	if !errors.As(err, &transportErr) || transportErr.Kind != OutcomeInconclusive {
+		t.Fatalf("Body() error = %v, want mixed absence/unavailable inconclusive", err)
+	}
+	if errors.Is(err, ErrArticleNotFound) {
+		t.Fatalf("Body() error = %v, unavailable provider must prevent global hard absence", err)
+	}
+	if len(transportErr.Attempts) != 2 ||
+		transportErr.Attempts[1].Outcome != OutcomeProviderUnavailable ||
+		!errors.Is(transportErr.Attempts[1].Cause, ErrQuotaExceeded) {
+		t.Errorf("attempts = %+v, want hard absence then quota unavailable", transportErr.Attempts)
+	}
+	if unavailable.commandCount("BODY") != 0 {
+		t.Errorf("quota-exceeded provider received %d BODY commands", unavailable.commandCount("BODY"))
 	}
 }
 
@@ -508,9 +734,13 @@ func TestPR1SuccessfulResultsExposeProviderAndAttempts(t *testing.T) {
 			return yencSinglePart(valid, "evidence.bin")
 		},
 	}
+	missingConfig := missing.provider(false)
+	missingConfig.ID = "provider-stable-missing"
+	servingConfig := serving.provider(false)
+	servingConfig.ID = "provider-stable-serving"
 	client, err := NewClient(
 		context.Background(),
-		[]Provider{missing.provider(false), serving.provider(false)},
+		[]Provider{missingConfig, servingConfig},
 		WithDispatchStrategy(DispatchFIFO),
 		WithStatProbe(false),
 	)
@@ -525,13 +755,549 @@ func TestPR1SuccessfulResultsExposeProviderAndAttempts(t *testing.T) {
 	if bodyErr != nil {
 		t.Fatalf("Body() error = %v", bodyErr)
 	}
-	requireProviderAndAttempts(t, body, serving.host, 2)
+	requireProviderAndAttempts(t, body, servingConfig.ID, 2)
 
 	stat, statErr := client.Stat(ctx, "fixture@example.invalid")
 	if statErr != nil {
 		t.Fatalf("Stat() error = %v", statErr)
 	}
-	requireProviderAndAttempts(t, stat, serving.host, 2)
+	requireProviderAndAttempts(t, stat, servingConfig.ID, 2)
+}
+
+func TestPR1StructuredTerminalClassifications(t *testing.T) {
+	t.Run("hard absence", func(t *testing.T) {
+		first := &regressionProvider{
+			host:    "hard-absence-primary.invalid:119",
+			respond: func(_ int, _ string) []byte { return []byte("423 no article with that number\r\n") },
+		}
+		backup := &regressionProvider{
+			host:    "hard-absence-backup.invalid:119",
+			respond: func(_ int, _ string) []byte { return []byte("430 no such article\r\n") },
+		}
+		client := newRegressionClient(t, first.provider(false), backup.provider(true))
+		_, err := client.Body(context.Background(), "fixture@example.invalid")
+		var transportErr *TransportError
+		if !errors.As(err, &transportErr) {
+			t.Fatalf("Body() error = %v, want TransportError", err)
+		}
+		if transportErr.Kind != OutcomeHardArticleAbsence || !errors.Is(err, ErrArticleNotFound) {
+			t.Fatalf("Body() error = %v, want structured hard absence preserving sentinel", err)
+		}
+		if len(transportErr.Attempts) != 2 || transportErr.Attempts[0].ResponseCode != 423 ||
+			transportErr.Attempts[1].ResponseCode != 430 {
+			t.Errorf("attempts = %+v, want ordered 423 then backup 430", transportErr.Attempts)
+		}
+	})
+
+	t.Run("unavailable", func(t *testing.T) {
+		provider := &regressionProvider{
+			host:    "unavailable.invalid:119",
+			respond: func(_ int, _ string) []byte { return []byte("502 service unavailable\r\n") },
+		}
+		client := newRegressionClient(t, provider.provider(false))
+		_, err := client.Body(context.Background(), "fixture@example.invalid")
+		var transportErr *TransportError
+		if !errors.As(err, &transportErr) {
+			t.Fatalf("Body() error = %v, want TransportError", err)
+		}
+		if transportErr.Kind != OutcomeProviderUnavailable || !errors.Is(err, ErrServiceUnavailable) {
+			t.Fatalf("Body() error = %v, want structured provider unavailable preserving sentinel", err)
+		}
+		if len(transportErr.Attempts) != 1 || transportErr.Attempts[0].ResponseCode != 502 {
+			t.Errorf("attempts = %+v, want one raw 502 record", transportErr.Attempts)
+		}
+	})
+
+	t.Run("caller cancellation", func(t *testing.T) {
+		provider := &regressionProvider{
+			host: "cancelled.invalid:119",
+			respond: func(_ int, _ string) []byte {
+				return yencSinglePart([]byte("must not be accepted"), "cancelled.bin")
+			},
+		}
+		client := newRegressionClient(t, provider.provider(false))
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := client.Body(ctx, "fixture@example.invalid")
+		var transportErr *TransportError
+		if !errors.As(err, &transportErr) {
+			t.Fatalf("Body() error = %v, want TransportError", err)
+		}
+		if transportErr.Kind != OutcomeCancellation || !errors.Is(err, context.Canceled) {
+			t.Fatalf("Body() error = %v, want structured caller cancellation", err)
+		}
+		if len(transportErr.Attempts) != 1 || transportErr.Attempts[0].ProviderResponseTimeout {
+			t.Errorf("attempts = %+v, want one local cancellation and no provider timeout", transportErr.Attempts)
+		}
+	})
+}
+
+func TestPR1ProviderResponseTimeoutIsSeparateEvidence(t *testing.T) {
+	hungFactory := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 regression server ready\r\n"))
+			reader := bufio.NewReader(server)
+			_, _ = reader.ReadString('\n')
+			<-ctx.Done()
+		}()
+		return client, nil
+	}
+	healthy := &regressionProvider{
+		host: "timeout-fallback.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return yencSinglePart([]byte("timeout fallback"), "timeout.bin")
+		},
+	}
+	client := newRegressionClient(t,
+		Provider{
+			ID:             "provider-timeout",
+			Host:           "timeout-primary.invalid:119",
+			Factory:        hungFactory,
+			Connections:    1,
+			Inflight:       1,
+			SkipPing:       true,
+			AttemptTimeout: 50 * time.Millisecond,
+		},
+		healthy.provider(true),
+	)
+	body, err := client.Body(context.Background(), "fixture@example.invalid")
+	if err != nil {
+		t.Fatalf("Body() error = %v", err)
+	}
+	if len(body.Attempts) != 2 {
+		t.Fatalf("attempt count = %d, want timeout then backup success", len(body.Attempts))
+	}
+	first := body.Attempts[0]
+	if first.ProviderID != "provider-timeout" || first.Outcome != OutcomeTransportFailure ||
+		!first.ProviderResponseTimeout {
+		t.Errorf("timeout evidence = %+v, want provider transport timeout", first)
+	}
+	if first.PoolQueueDuration < 0 || first.PipelineHeadWaitDuration < 0 ||
+		first.ResponseServiceDuration < 40*time.Millisecond {
+		t.Errorf("timeout durations = queue %v, head %v, service %v", first.PoolQueueDuration,
+			first.PipelineHeadWaitDuration, first.ResponseServiceDuration)
+	}
+	if body.Attempts[1].Outcome != OutcomeSuccess || body.ProviderID != healthy.host {
+		t.Errorf("fallback result = provider %q attempts %+v", body.ProviderID, body.Attempts)
+	}
+}
+
+func TestPR1BufferedBodyValidationFallbackMatrix(t *testing.T) {
+	validPayload := []byte("strict validation fallback")
+	base := yencSinglePart([]byte("invalid provider payload"), "invalid.bin")
+
+	replaceRequired := func(input []byte, oldValue, newValue string) []byte {
+		t.Helper()
+		output := bytes.Replace(bytes.Clone(input), []byte(oldValue), []byte(newValue), 1)
+		if bytes.Equal(output, input) {
+			t.Fatalf("fixture does not contain %q", oldValue)
+		}
+		return output
+	}
+
+	badPart := replaceRequired(base, "part=1", "part=2")
+	missingBegin := replaceRequired(base, "=ybegin", "=xbegin")
+	badFileSize := replaceRequired(base, " size=24", " size=25")
+	badTrailerSize := replaceRequired(base, "=yend size=24", "=yend size=99")
+	malformedTrailer := replaceRequired(base, "=yend size=24", "=yend size=xx")
+	malformedCRC := bytes.Clone(base)
+	crcIndex := bytes.Index(malformedCRC, []byte("crc32="))
+	if crcIndex < 0 {
+		t.Fatal("fixture does not contain crc32")
+	}
+	copy(malformedCRC[crcIndex+len("crc32="):], "zzzzzzzz")
+	zeroCRCMismatch := bytes.Clone(base)
+	copy(zeroCRCMismatch[crcIndex+len("crc32="):], "00000000")
+	shortPayload := bytes.Clone(base)
+	trailerIndex := bytes.Index(shortPayload, []byte("\r\n=yend "))
+	if trailerIndex < 2 {
+		t.Fatal("fixture does not contain an encoded payload")
+	}
+	shortPayload = append(shortPayload[:trailerIndex-1], shortPayload[trailerIndex:]...)
+
+	cases := map[string][]byte{
+		"missing_ybegin":    missingBegin,
+		"invalid_part":      badPart,
+		"file_size":         badFileSize,
+		"decoded_size":      badTrailerSize,
+		"malformed_trailer": malformedTrailer,
+		"malformed_crc":     malformedCRC,
+		"zero_crc_mismatch": zeroCRCMismatch,
+		"short_payload":     shortPayload,
+	}
+	for name, invalidResponse := range cases {
+		t.Run(name, func(t *testing.T) {
+			invalid := &regressionProvider{
+				host: "invalid-" + name + ".invalid:119",
+				respond: func(_ int, _ string) []byte {
+					return invalidResponse
+				},
+			}
+			valid := &regressionProvider{
+				host: "valid-" + name + ".invalid:119",
+				respond: func(_ int, _ string) []byte {
+					return yencSinglePart(validPayload, "valid.bin")
+				},
+			}
+			client := newRegressionClient(t, invalid.provider(false), valid.provider(false))
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			body, err := client.Body(ctx, "fixture@example.invalid")
+			if err != nil {
+				t.Fatalf("Body() error = %v", err)
+			}
+			if !bytes.Equal(body.Bytes, validPayload) {
+				t.Fatalf("Body() bytes = %q, want validated fallback", body.Bytes)
+			}
+			if len(body.Attempts) != 2 || body.Attempts[0].Outcome != OutcomeCorruptBody {
+				t.Errorf("attempts = %+v, want corrupt then success", body.Attempts)
+			}
+		})
+	}
+}
+
+func TestPR1ZeroCRCIsValidated(t *testing.T) {
+	zeroCRC := []byte{0x9d, 0x0a, 0xd9, 0x6d}
+	provider := &regressionProvider{
+		host: "zero-crc.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return yencSinglePart(zeroCRC, "zero.bin")
+		},
+	}
+	client := newRegressionClient(t, provider.provider(false))
+	body, err := client.Body(context.Background(), "fixture@example.invalid")
+	if err != nil {
+		t.Fatalf("Body() error = %v", err)
+	}
+	if body.CRC != 0 || body.ExpectedCRC != 0 || !body.CRCProvided || !body.CRCValid {
+		t.Errorf("CRC fields = actual:%08x expected:%08x provided:%v valid:%v, want supplied zero CRC validated", body.CRC, body.ExpectedCRC, body.CRCProvided, body.CRCValid)
+	}
+}
+
+func TestPR1NativeDecodeErrorPropagates(t *testing.T) {
+	nativeErr := errors.New("native decoder regression")
+	response := NNTPResponse{
+		body:   true,
+		Format: 1,
+		decodeFn: func([]byte, []byte, *rapidyenc.State) (int, int, rapidyenc.End, error) {
+			return 0, 0, rapidyenc.EndNone, nativeErr
+		},
+	}
+	_, err := response.decodeYenc([]byte("encoded"), io.Discard)
+	if !errors.Is(err, nativeErr) || !errors.Is(err, ErrBodyCorrupt) {
+		t.Fatalf("decodeYenc() error = %v, want native error wrapped as corruption", err)
+	}
+}
+
+func TestPR1ParallelProbePreservesConfiguredOrderAndEvidence(t *testing.T) {
+	missing := &regressionProvider{
+		host:    "probe-missing.invalid:119",
+		respond: func(_ int, _ string) []byte { return []byte("430 no such article\r\n") },
+	}
+	preferred := &regressionProvider{
+		host: "probe-preferred.invalid:119",
+		respond: func(_ int, command string) []byte {
+			if strings.HasPrefix(command, "STAT") {
+				time.Sleep(80 * time.Millisecond)
+				return []byte("223 1 <fixture@example.invalid> exists\r\n")
+			}
+			return yencSinglePart([]byte("preferred"), "preferred.bin")
+		},
+	}
+	fasterLater := &regressionProvider{
+		host: "probe-faster.invalid:119",
+		respond: func(_ int, command string) []byte {
+			if strings.HasPrefix(command, "STAT") {
+				return []byte("223 1 <fixture@example.invalid> exists\r\n")
+			}
+			return yencSinglePart([]byte("later"), "later.bin")
+		},
+	}
+	client := newRegressionClient(t, missing.provider(false), preferred.provider(false), fasterLater.provider(false))
+	body, err := client.Body(context.Background(), "fixture@example.invalid")
+	if err != nil {
+		t.Fatalf("Body() error = %v", err)
+	}
+	if body.ProviderID != preferred.host || !bytes.Equal(body.Bytes, []byte("preferred")) {
+		t.Fatalf("serving provider/body = %q/%q, want configured preferred provider", body.ProviderID, body.Bytes)
+	}
+	if fasterLater.commandCount("BODY") != 0 {
+		t.Errorf("faster later provider received %d BODY commands, want 0", fasterLater.commandCount("BODY"))
+	}
+	wantProviders := []string{missing.host, preferred.host, fasterLater.host, preferred.host}
+	if len(body.Attempts) != len(wantProviders) {
+		t.Fatalf("attempt count = %d, want %d", len(body.Attempts), len(wantProviders))
+	}
+	for index, want := range wantProviders {
+		if got := body.Attempts[index].ProviderID; got != want {
+			t.Errorf("attempt %d provider = %q, want %q", index, got, want)
+		}
+	}
+}
+
+func TestPR1UnknownResponseRemainsInconclusive(t *testing.T) {
+	provider := &regressionProvider{
+		host:    "vendor-code.invalid:119",
+		respond: func(_ int, _ string) []byte { return []byte("499 vendor-specific failure\r\n") },
+	}
+	client := newRegressionClient(t, provider.provider(false))
+	_, err := client.Body(context.Background(), "fixture@example.invalid")
+	var transportErr *TransportError
+	if !errors.As(err, &transportErr) {
+		t.Fatalf("Body() error = %v, want TransportError", err)
+	}
+	if transportErr.Kind != OutcomeInconclusive || transportErr.ResponseCode != 499 {
+		t.Errorf("transport outcome/code = %s/%d, want inconclusive/499", transportErr.Kind, transportErr.ResponseCode)
+	}
+	if errors.Is(err, ErrArticleNotFound) {
+		t.Fatalf("unknown vendor response matched hard absence: %v", err)
+	}
+}
+
+func TestPR1TargetedBodyCanRequireFreshTransport(t *testing.T) {
+	provider := &regressionProvider{
+		host: "targeted-fresh.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return yencSinglePart([]byte("targeted"), "targeted.bin")
+		},
+	}
+	client := newRegressionClient(t, provider.provider(false))
+	if _, err := client.Body(context.Background(), "first@example.invalid"); err != nil {
+		t.Fatalf("initial Body() error = %v", err)
+	}
+	body, err := client.BodyTargeted(context.Background(), "second@example.invalid", TargetedBodyOptions{
+		Provider:       provider.host,
+		FreshTransport: true,
+		Priority:       true,
+	})
+	if err != nil {
+		t.Fatalf("BodyTargeted() error = %v", err)
+	}
+	if body.ProviderID != provider.host {
+		t.Errorf("BodyTargeted() provider = %q, want %q", body.ProviderID, provider.host)
+	}
+	if got := provider.connections.Load(); got != 2 {
+		t.Errorf("provider connections = %d, want fresh second transport", got)
+	}
+}
+
+func TestPR1PipelineWaitDoesNotConsumeResponseTimeout(t *testing.T) {
+	response := yencSinglePart(bytes.Repeat([]byte("p"), 128*1024), "pipeline.bin")
+	factory := func(context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 regression server ready\r\n"))
+			reader := bufio.NewReader(server)
+			_, _ = reader.ReadString('\n')
+			chunk := len(response) / 8
+			for offset := 0; offset < len(response); offset += chunk {
+				end := min(offset+chunk, len(response))
+				_, _ = server.Write(response[offset:end])
+				if end < len(response) {
+					time.Sleep(25 * time.Millisecond)
+				}
+			}
+			_, _ = reader.ReadString('\n')
+			_, _ = server.Write(yencSinglePart([]byte("second"), "second.bin"))
+		}()
+		return client, nil
+	}
+	client := newRegressionClient(t, Provider{
+		Host:           "dual-clock.invalid:119",
+		Factory:        factory,
+		Connections:    1,
+		Inflight:       2,
+		SkipPing:       true,
+		AttemptTimeout: 70 * time.Millisecond,
+		StallTimeout:   300 * time.Millisecond,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	type result struct {
+		body *ArticleBody
+		err  error
+	}
+	results := make(chan result, 2)
+	for _, id := range []string{"first@example.invalid", "second@example.invalid"} {
+		go func(messageID string) {
+			body, err := client.Body(ctx, messageID)
+			results <- result{body: body, err: err}
+		}(id)
+	}
+	var maxHeadWait time.Duration
+	for range 2 {
+		result := <-results
+		if result.err != nil {
+			var transportErr *TransportError
+			if errors.As(result.err, &transportErr) {
+				t.Fatalf("pipelined Body() error = %v; attempts = %+v", result.err, transportErr.Attempts)
+			}
+			t.Fatalf("pipelined Body() error = %v", result.err)
+		}
+		if len(result.body.Attempts) != 1 {
+			t.Fatalf("attempt count = %d, want 1", len(result.body.Attempts))
+		}
+		maxHeadWait = max(maxHeadWait, result.body.Attempts[0].PipelineHeadWaitDuration)
+	}
+	if maxHeadWait < 150*time.Millisecond {
+		t.Errorf("maximum pipeline head wait = %v, want evidence of >150ms wait outside 70ms response timeout", maxHeadWait)
+	}
+}
+
+func TestPR1UnsentPriorityPrecedesQueuedNormalWork(t *testing.T) {
+	commands := make(chan string, 3)
+	releaseFirst := make(chan struct{})
+	factory := func(context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 regression server ready\r\n"))
+			reader := bufio.NewReader(server)
+			for index := 0; ; index++ {
+				command, err := reader.ReadString('\n')
+				if err != nil {
+					return
+				}
+				command = strings.TrimSpace(command)
+				commands <- command
+				if index == 0 {
+					<-releaseFirst
+				}
+				if strings.HasPrefix(command, "BODY") {
+					_, _ = server.Write(yencSinglePart([]byte("priority"), "priority.bin"))
+				} else {
+					_, _ = server.Write([]byte("223 1 <fixture@example.invalid> exists\r\n"))
+				}
+			}
+		}()
+		return client, nil
+	}
+	client := newRegressionClient(t, Provider{
+		Host:         "strict-priority.invalid:119",
+		Factory:      factory,
+		Connections:  1,
+		Inflight:     1,
+		StatInflight: 1,
+		SkipPing:     true,
+	})
+	results := make(chan error, 3)
+	go func() {
+		_, err := client.Stat(context.Background(), "first@example.invalid")
+		results <- err
+	}()
+	if first := <-commands; !strings.HasPrefix(first, "STAT") {
+		t.Fatalf("first command = %q, want blocking STAT", first)
+	}
+	go func() {
+		_, err := client.Stat(context.Background(), "normal@example.invalid")
+		results <- err
+	}()
+	go func() {
+		_, err := client.BodyPriority(context.Background(), "priority@example.invalid")
+		results <- err
+	}()
+	group := (*client.mainGroups.Load())[0]
+	deadline := time.Now().Add(time.Second)
+	for (len(group.reqCh) == 0 || len(group.prioCh) == 0) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	close(releaseFirst)
+	if second := <-commands; !strings.HasPrefix(second, "BODY") {
+		t.Errorf("second command = %q, want priority BODY before queued normal STAT", second)
+	}
+	for range 3 {
+		if err := <-results; err != nil {
+			t.Errorf("request error = %v", err)
+		}
+	}
+}
+
+func TestPR1BackgroundStatWindowPreservesPriorityHeadroom(t *testing.T) {
+	commands := make(chan string, 5)
+	release := make(chan struct{})
+	factory := func(context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer func() { _ = server.Close() }()
+			_, _ = server.Write([]byte("200 regression server ready\r\n"))
+			reader := bufio.NewReader(server)
+			for index := 0; ; index++ {
+				command, err := reader.ReadString('\n')
+				if err != nil {
+					return
+				}
+				commands <- strings.TrimSpace(command)
+				if index == 2 {
+					<-release
+					for range 3 {
+						_, _ = server.Write([]byte("223 1 <fixture@example.invalid> exists\r\n"))
+					}
+				} else if index > 2 {
+					_, _ = server.Write([]byte("223 1 <fixture@example.invalid> exists\r\n"))
+				}
+			}
+		}()
+		return client, nil
+	}
+	client := newRegressionClient(t, Provider{
+		Host:                   "occupancy.invalid:119",
+		Factory:                factory,
+		Connections:            1,
+		Inflight:               1,
+		StatInflight:           4,
+		BackgroundStatInflight: 2,
+		PriorityHeadroom:       1,
+		SkipPing:               true,
+	})
+	results := make(chan error, 5)
+	for index := range 4 {
+		go func(index int) {
+			_, err := client.Stat(context.Background(), "background-"+string(rune('a'+index))+"@example.invalid")
+			results <- err
+		}(index)
+	}
+	for range 2 {
+		select {
+		case command := <-commands:
+			if !strings.HasPrefix(command, "STAT") {
+				t.Fatalf("background command = %q, want STAT", command)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("background STAT window did not fill")
+		}
+	}
+	select {
+	case command := <-commands:
+		t.Fatalf("ordinary background exceeded configured window before priority: %q", command)
+	case <-time.After(50 * time.Millisecond):
+	}
+	go func() {
+		_, err := client.StatPriority(context.Background(), "priority@example.invalid")
+		results <- err
+	}()
+	select {
+	case command := <-commands:
+		if !strings.Contains(command, "priority@example.invalid") {
+			t.Fatalf("third command = %q, want priority STAT in reserved headroom", command)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("priority STAT did not use reserved pipeline headroom")
+	}
+	stats := client.Stats().Providers[0]
+	if stats.BackgroundStatInUse != 2 || stats.BackgroundStatLimit != 2 ||
+		stats.PipelineInUse != 3 || stats.PipelineLimit != 4 || stats.PriorityHeadroom != 1 {
+		t.Errorf("occupancy stats = %+v, want background 2/2, pipeline 3/4, headroom 1", stats)
+	}
+	close(release)
+	for range 5 {
+		if err := <-results; err != nil {
+			t.Errorf("STAT error = %v", err)
+		}
+	}
 }
 
 func requireProviderAndAttempts(t *testing.T, result any, providerID string, wantAttempts int) {

--- a/pr1_regression_test.go
+++ b/pr1_regression_test.go
@@ -390,6 +390,9 @@ func TestPR1CancelledPipelineDoesNotDelayNewPriorityBody(t *testing.T) {
 	if got := connections.Load(); got < 2 {
 		t.Errorf("connections = %d, want canceled pipeline socket retired", got)
 	}
+	if errorsCount := client.Stats().Providers[0].Errors; errorsCount != 0 {
+		t.Errorf("provider errors = %d, caller cancellation must not count as provider failure", errorsCount)
+	}
 }
 
 func BenchmarkPR1AbandonedBodyDrainCaps(b *testing.B) {
@@ -1145,6 +1148,13 @@ func TestPR1PipelineWaitDoesNotConsumeResponseTimeout(t *testing.T) {
 	}
 	if maxHeadWait < 150*time.Millisecond {
 		t.Errorf("maximum pipeline head wait = %v, want evidence of >150ms wait outside 70ms response timeout", maxHeadWait)
+	}
+	providerStats := client.Stats().Providers[0]
+	if providerStats.TTFB >= 70*time.Millisecond {
+		t.Errorf("provider TTFB = %v, pipeline wait contaminated response-head timing", providerStats.TTFB)
+	}
+	if providerStats.Errors != 0 {
+		t.Errorf("provider errors = %d, pipeline wait must not count as provider failure", providerStats.Errors)
 	}
 }
 

--- a/pr1_regression_test.go
+++ b/pr1_regression_test.go
@@ -1,0 +1,576 @@
+package nntppool
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const regressionBodySize = 2 * 1024 * 1024
+
+type blockingWriter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.started) })
+	<-w.release
+	return len(p), nil
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type regressionProvider struct {
+	host        string
+	connections atomic.Int32
+	mu          sync.Mutex
+	commands    []string
+	respond     func(connection int, command string) []byte
+}
+
+func (p *regressionProvider) provider(backup bool) Provider {
+	return Provider{
+		Host:        p.host,
+		Factory:     p.factory,
+		Connections: 1,
+		Inflight:    1,
+		Backup:      backup,
+		SkipPing:    true,
+	}
+}
+
+func (p *regressionProvider) factory(context.Context) (net.Conn, error) {
+	connection := int(p.connections.Add(1))
+	client, server := net.Pipe()
+	go func() {
+		defer func() { _ = server.Close() }()
+		if _, err := server.Write([]byte("200 regression server ready\r\n")); err != nil {
+			return
+		}
+		reader := bufio.NewReader(server)
+		for {
+			command, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			command = strings.TrimSuffix(strings.TrimSuffix(command, "\n"), "\r")
+			p.mu.Lock()
+			p.commands = append(p.commands, command)
+			p.mu.Unlock()
+			response := p.respond(connection, command)
+			if len(response) == 0 {
+				response = []byte("500 unexpected regression command\r\n")
+			}
+			if _, err := server.Write(response); err != nil {
+				return
+			}
+		}
+	}()
+	return client, nil
+}
+
+func (p *regressionProvider) commandCount(prefix string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	count := 0
+	for _, command := range p.commands {
+		if strings.HasPrefix(command, prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+func newRegressionClient(t *testing.T, providers ...Provider) *Client {
+	t.Helper()
+	client, err := NewClient(
+		context.Background(),
+		providers,
+		WithDispatchStrategy(DispatchFIFO),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func corruptCRC(response []byte) []byte {
+	corrupt := bytes.Clone(response)
+	marker := []byte("crc32=")
+	index := bytes.Index(corrupt, marker)
+	if index < 0 {
+		panic("yEnc fixture did not contain a CRC")
+	}
+	copy(corrupt[index+len(marker):], "deadbeef")
+	return corrupt
+}
+
+func removeYEnd(response []byte) []byte {
+	truncated := bytes.Clone(response)
+	start := bytes.Index(truncated, []byte("\r\n=yend "))
+	if start < 0 {
+		panic("yEnc fixture did not contain =yend")
+	}
+	end := bytes.Index(truncated[start+2:], []byte("\r\n"))
+	if end < 0 {
+		panic("yEnc fixture contained an unterminated =yend")
+	}
+	end += start + 4
+	return append(truncated[:start], truncated[end:]...)
+}
+
+func TestPR1PrebufferedDecodedBytesCommitAttempt(t *testing.T) {
+	firstBody := yencSinglePart([]byte("first response"), "first.bin")
+	secondBody := yencSinglePart([]byte("second response"), "second.bin")
+
+	commandsRead := make(chan struct{})
+	conn := mockServer(t, func(server net.Conn) {
+		_, _ = server.Write([]byte("200 regression server ready\r\n"))
+		reader := bufio.NewReader(server)
+		_, _ = reader.ReadString('\n')
+		_, _ = reader.ReadString('\n')
+		close(commandsRead)
+		combined := append(bytes.Clone(firstBody), secondBody...)
+		_, _ = server.Write(combined)
+	})
+
+	reqCh := make(chan *Request, 2)
+	nc, err := newNNTPConnectionFromConn(
+		context.Background(), conn, 2, reqCh, nil, Auth{}, "", nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newNNTPConnectionFromConn() error = %v", err)
+	}
+	t.Cleanup(func() { _ = nc.Close() })
+
+	blocked := &blockingWriter{started: make(chan struct{}), release: make(chan struct{})}
+	first := &Request{
+		Ctx:        context.Background(),
+		Payload:    []byte("BODY <first@example.invalid>\r\n"),
+		RespCh:     make(chan Response, 1),
+		BodyWriter: io.Discard,
+	}
+	second := &Request{
+		Ctx:        context.Background(),
+		Payload:    []byte("BODY <second@example.invalid>\r\n"),
+		RespCh:     make(chan Response, 1),
+		BodyWriter: blocked,
+	}
+	reqCh <- first
+	reqCh <- second
+	go nc.Run()
+
+	select {
+	case <-commandsRead:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive both pipelined BODY commands")
+	}
+	select {
+	case <-blocked.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second response did not deliver decoded bytes")
+	}
+
+	if state := second.attemptState.Load(); state != attemptCommitted {
+		t.Errorf("attempt state after prebuffered decoded delivery = %d, want committed", state)
+	}
+	close(blocked.release)
+}
+
+func TestPR1WriterFailureRetiresConnection(t *testing.T) {
+	writerErr := errors.New("regression writer failure")
+	conn := mockServer(t, func(server net.Conn) {
+		_, _ = server.Write([]byte("200 regression server ready\r\n"))
+		reader := bufio.NewReader(server)
+		_, _ = reader.ReadString('\n')
+		_, _ = server.Write(yencSinglePart(bytes.Repeat([]byte("x"), 32*1024), "writer.bin"))
+		_, _ = reader.ReadString('\n')
+	})
+
+	reqCh := make(chan *Request, 1)
+	nc, err := newNNTPConnectionFromConn(
+		context.Background(), conn, 1, reqCh, nil, Auth{}, "", nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("newNNTPConnectionFromConn() error = %v", err)
+	}
+	t.Cleanup(func() { _ = nc.Close() })
+
+	respCh := make(chan Response, 1)
+	reqCh <- &Request{
+		Ctx:        context.Background(),
+		Payload:    []byte("BODY <writer@example.invalid>\r\n"),
+		RespCh:     respCh,
+		BodyWriter: failingWriter{err: writerErr},
+	}
+	go nc.Run()
+
+	select {
+	case response := <-respCh:
+		if !errors.Is(response.Err, writerErr) {
+			t.Fatalf("BODY error = %v, want writer failure", response.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("BODY writer failure was not returned")
+	}
+
+	select {
+	case <-nc.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Error("connection remained reusable after a BODY writer failure")
+	}
+}
+
+func TestPR1CancelledBodyDrainIsBounded(t *testing.T) {
+	body := yencSinglePart(bytes.Repeat([]byte("z"), regressionBodySize), "cancel.bin")
+
+	for _, depth := range []int{1, 4, 10} {
+		t.Run(strings.Repeat("pipeline_", depth)+"cancel", func(t *testing.T) {
+			firstChunkWritten := make(chan struct{})
+			writtenResult := make(chan int, 1)
+			conn := mockServer(t, func(server net.Conn) {
+				_, _ = server.Write([]byte("200 regression server ready\r\n"))
+				reader := bufio.NewReader(server)
+				for range depth {
+					_, _ = reader.ReadString('\n')
+				}
+
+				written := 0
+				signaled := false
+				for range depth {
+					for offset := 0; offset < len(body); {
+						end := min(offset+32*1024, len(body))
+						n, err := server.Write(body[offset:end])
+						written += n
+						if !signaled && written > 0 {
+							close(firstChunkWritten)
+							signaled = true
+						}
+						offset += n
+						if err != nil {
+							writtenResult <- written
+							return
+						}
+					}
+				}
+				writtenResult <- written
+			})
+
+			reqCh := make(chan *Request, depth)
+			nc, err := newNNTPConnectionFromConn(
+				context.Background(), conn, depth, reqCh, nil, Auth{}, "", nil, nil,
+			)
+			if err != nil {
+				t.Fatalf("newNNTPConnectionFromConn() error = %v", err)
+			}
+			t.Cleanup(func() { _ = nc.Close() })
+
+			cancels := make([]context.CancelFunc, 0, depth)
+			for index := range depth {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancels = append(cancels, cancel)
+				reqCh <- &Request{
+					Ctx:        ctx,
+					Payload:    []byte("BODY <cancel-" + string(rune('a'+index)) + "@example.invalid>\r\n"),
+					RespCh:     make(chan Response, 1),
+					BodyWriter: io.Discard,
+				}
+			}
+			go nc.Run()
+
+			select {
+			case <-firstChunkWritten:
+			case <-time.After(2 * time.Second):
+				t.Fatal("server did not begin the first BODY response")
+			}
+			for _, cancel := range cancels {
+				cancel()
+			}
+
+			var written int
+			select {
+			case written = <-writtenResult:
+			case <-time.After(5 * time.Second):
+				t.Fatal("cancelled BODY drain did not finish or retire the connection")
+			}
+			if full := len(body) * depth; written >= full {
+				t.Errorf("cancelled depth %d drained %d bytes, want a bounded drain below full %d-byte tail", depth, written, full)
+			}
+		})
+	}
+}
+
+func TestPR1ArticleAbsenceFallbackIncludes423(t *testing.T) {
+	valid := []byte("valid fallback payload")
+
+	for _, operation := range []string{"BODY", "STAT"} {
+		t.Run(operation, func(t *testing.T) {
+			first := &regressionProvider{
+				host: "absence-primary.invalid:119",
+				respond: func(_ int, _ string) []byte {
+					return []byte("423 no article with that number\r\n")
+				},
+			}
+			second := &regressionProvider{
+				host: "available-primary.invalid:119",
+				respond: func(_ int, command string) []byte {
+					if strings.HasPrefix(command, "STAT") {
+						return []byte("223 7 <fixture@example.invalid> article exists\r\n")
+					}
+					return yencSinglePart(valid, "valid.bin")
+				},
+			}
+			client := newRegressionClient(t, first.provider(false), second.provider(false))
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			switch operation {
+			case "BODY":
+				body, err := client.Body(ctx, "fixture@example.invalid")
+				if err != nil {
+					t.Fatalf("Body() error = %v", err)
+				}
+				if !bytes.Equal(body.Bytes, valid) {
+					t.Fatalf("Body() bytes = %q, want fallback payload", body.Bytes)
+				}
+			case "STAT":
+				if _, err := client.Stat(ctx, "fixture@example.invalid"); err != nil {
+					t.Fatalf("Stat() error = %v", err)
+				}
+			}
+			if second.commandCount(operation) == 0 {
+				t.Errorf("second provider did not receive %s after 423", operation)
+			}
+		})
+	}
+}
+
+func TestPR1451RetriesFreshThenFallsBack(t *testing.T) {
+	valid := []byte("temporary fallback payload")
+	first := &regressionProvider{
+		host: "temporary-primary.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return []byte("451 temporary server failure\r\n")
+		},
+	}
+	second := &regressionProvider{
+		host: "available-backup.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return yencSinglePart(valid, "temporary.bin")
+		},
+	}
+	client := newRegressionClient(t, first.provider(false), second.provider(true))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	body, err := client.Body(ctx, "fixture@example.invalid")
+	if err != nil {
+		t.Fatalf("Body() error = %v", err)
+	}
+	if !bytes.Equal(body.Bytes, valid) {
+		t.Fatalf("Body() bytes = %q, want backup payload", body.Bytes)
+	}
+	if got := first.connections.Load(); got != 2 {
+		t.Errorf("temporary provider connections = %d, want one fresh retry (2 total)", got)
+	}
+	if second.commandCount("BODY") != 1 {
+		t.Errorf("backup BODY attempts = %d, want 1", second.commandCount("BODY"))
+	}
+}
+
+func TestPR1MixedAbsenceAndTemporaryIsInconclusive(t *testing.T) {
+	first := &regressionProvider{
+		host: "missing-primary.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return []byte("430 no such article\r\n")
+		},
+	}
+	second := &regressionProvider{
+		host: "temporary-secondary.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return []byte("451 temporary server failure\r\n")
+		},
+	}
+	third := &regressionProvider{
+		host: "missing-tertiary.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return []byte("430 no such article\r\n")
+		},
+	}
+	client := newRegressionClient(t, first.provider(false), second.provider(false), third.provider(false))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err := client.Body(ctx, "fixture@example.invalid")
+	if err == nil {
+		t.Fatal("Body() error = nil, want an inconclusive temporary outcome")
+	}
+	if errors.Is(err, ErrArticleNotFound) {
+		t.Fatalf("Body() error = %v, mixed absence and temporary must not be hard absence", err)
+	}
+	if second.commandCount("STAT") == 0 || third.commandCount("STAT") == 0 {
+		t.Fatalf("parallel probe commands: temporary=%d missing=%d, want both attempted", second.commandCount("STAT"), third.commandCount("STAT"))
+	}
+}
+
+func TestPR1BufferedBodyCorruptionFallsBack(t *testing.T) {
+	valid := []byte("validated payload")
+	first := &regressionProvider{
+		host: "corrupt-primary.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return corruptCRC(yencSinglePart([]byte("corrupt payload"), "corrupt.bin"))
+		},
+	}
+	second := &regressionProvider{
+		host: "valid-primary.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return yencSinglePart(valid, "valid.bin")
+		},
+	}
+	client := newRegressionClient(t, first.provider(false), second.provider(false))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	body, err := client.Body(ctx, "fixture@example.invalid")
+	if err != nil {
+		t.Fatalf("Body() error = %v", err)
+	}
+	if !bytes.Equal(body.Bytes, valid) {
+		t.Fatalf("Body() bytes = %q, want validated fallback payload", body.Bytes)
+	}
+	if second.commandCount("BODY") != 1 {
+		t.Errorf("valid provider BODY attempts = %d, want 1", second.commandCount("BODY"))
+	}
+}
+
+func TestPR1BufferedBodyMissingTrailerFallsBack(t *testing.T) {
+	valid := []byte("complete payload")
+	first := &regressionProvider{
+		host: "truncated-primary.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return removeYEnd(yencSinglePart([]byte("truncated payload"), "truncated.bin"))
+		},
+	}
+	second := &regressionProvider{
+		host: "complete-primary.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return yencSinglePart(valid, "complete.bin")
+		},
+	}
+	client := newRegressionClient(t, first.provider(false), second.provider(false))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	body, err := client.Body(ctx, "fixture@example.invalid")
+	if err != nil {
+		t.Fatalf("Body() error = %v", err)
+	}
+	if !bytes.Equal(body.Bytes, valid) {
+		t.Fatalf("Body() bytes = %q, want complete fallback payload", body.Bytes)
+	}
+	if second.commandCount("BODY") != 1 {
+		t.Errorf("complete provider BODY attempts = %d, want 1", second.commandCount("BODY"))
+	}
+}
+
+func TestPR1SuccessfulResultsExposeProviderAndAttempts(t *testing.T) {
+	valid := []byte("evidence payload")
+	missing := &regressionProvider{
+		host: "evidence-missing.invalid:119",
+		respond: func(_ int, _ string) []byte {
+			return []byte("430 no such article\r\n")
+		},
+	}
+	serving := &regressionProvider{
+		host: "evidence-serving.invalid:119",
+		respond: func(_ int, command string) []byte {
+			if strings.HasPrefix(command, "STAT") {
+				return []byte("223 9 <fixture@example.invalid> article exists\r\n")
+			}
+			return yencSinglePart(valid, "evidence.bin")
+		},
+	}
+	client, err := NewClient(
+		context.Background(),
+		[]Provider{missing.provider(false), serving.provider(false)},
+		WithDispatchStrategy(DispatchFIFO),
+		WithStatProbe(false),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	body, bodyErr := client.Body(ctx, "fixture@example.invalid")
+	if bodyErr != nil {
+		t.Fatalf("Body() error = %v", bodyErr)
+	}
+	requireProviderAndAttempts(t, body, serving.host, 2)
+
+	stat, statErr := client.Stat(ctx, "fixture@example.invalid")
+	if statErr != nil {
+		t.Fatalf("Stat() error = %v", statErr)
+	}
+	requireProviderAndAttempts(t, stat, serving.host, 2)
+}
+
+func requireProviderAndAttempts(t *testing.T, result any, providerID string, wantAttempts int) {
+	t.Helper()
+	value := reflect.Indirect(reflect.ValueOf(result))
+	provider := value.FieldByName("ProviderID")
+	if !provider.IsValid() || provider.Kind() != reflect.String {
+		t.Errorf("%T does not expose additive string ProviderID", result)
+		return
+	}
+	if got := provider.String(); got != providerID {
+		t.Errorf("%T ProviderID = %q, want %q", result, got, providerID)
+	}
+
+	attempts := value.FieldByName("Attempts")
+	if !attempts.IsValid() || attempts.Kind() != reflect.Slice {
+		t.Errorf("%T does not expose additive Attempts evidence", result)
+		return
+	}
+	if attempts.Len() != wantAttempts {
+		t.Errorf("%T attempt count = %d, want %d", result, attempts.Len(), wantAttempts)
+		return
+	}
+	for index := 0; index < attempts.Len(); index++ {
+		attempt := reflect.Indirect(attempts.Index(index))
+		for _, fieldName := range []string{
+			"ProviderID",
+			"Operation",
+			"Outcome",
+			"PoolQueueDuration",
+			"PipelineHeadWaitDuration",
+			"ResponseServiceDuration",
+		} {
+			if !attempt.FieldByName(fieldName).IsValid() {
+				t.Errorf("attempt %d does not expose %s", index, fieldName)
+			}
+		}
+		if attempt.FieldByName("ProviderGeneration").IsValid() {
+			t.Errorf("attempt %d exposes AltMount-owned ProviderGeneration", index)
+		}
+	}
+}

--- a/readBuffer.go
+++ b/readBuffer.go
@@ -114,14 +114,41 @@ func (rb *readBuffer) readMore(conn net.Conn, deadline time.Time, hasDeadline bo
 // bound), and to detect progress even when the decoder consumes 0 bytes from a
 // partial line.
 func (rb *readBuffer) feedUntilDone(conn net.Conn, feeder streamFeeder, out io.Writer, deadline func(wireBytes int) (time.Time, bool)) error {
+	return rb.feedUntilDoneControlled(
+		conn,
+		feeder,
+		out,
+		func(wireBytes, _ int) (time.Time, bool, int, error) {
+			dl, ok := deadline(wireBytes)
+			return dl, ok, 0, nil
+		},
+	)
+}
+
+// feedUntilDoneControlled is feedUntilDone with an additional response-byte
+// budget. control receives both bytes read from conn during this response and
+// total bytes consumed by the feeder, including bytes that were already in the
+// shared read buffer. maxFeed limits the next feeder call; zero means
+// unlimited. This lets abandoned BODY responses drain a bounded wire prefix
+// without accidentally ignoring a large prebuffered tail.
+func (rb *readBuffer) feedUntilDoneControlled(
+	conn net.Conn,
+	feeder streamFeeder,
+	out io.Writer,
+	control func(wireBytes, consumedBytes int) (deadline time.Time, hasDeadline bool, maxFeed int, err error),
+) error {
 	rb.init()
 	wireBytes := 0
+	consumedBytes := 0
 
 	for {
 		// Ensure we have some bytes to feed.
 		if rb.start == rb.end {
 			rb.start, rb.end = 0, 0
-			dl, ok := deadline(wireBytes)
+			dl, ok, _, controlErr := control(wireBytes, consumedBytes)
+			if controlErr != nil {
+				return controlErr
+			}
 			n, err := rb.readMore(conn, dl, ok)
 			wireBytes += n
 			if err != nil {
@@ -129,15 +156,27 @@ func (rb *readBuffer) feedUntilDone(conn net.Conn, feeder streamFeeder, out io.W
 			}
 		}
 
-		consumed, done, err := feeder.Feed(rb.window(), out)
+		_, _, maxFeed, controlErr := control(wireBytes, consumedBytes)
+		if controlErr != nil {
+			return controlErr
+		}
+		window := rb.window()
+		if maxFeed > 0 && len(window) > maxFeed {
+			window = window[:maxFeed]
+		}
+		consumed, done, err := feeder.Feed(window, out)
 		if consumed > 0 {
 			rb.advance(consumed)
+			consumedBytes += consumed
 		}
 		if err != nil {
 			return err
 		}
 		if done {
 			return nil
+		}
+		if _, _, _, controlErr = control(wireBytes, consumedBytes); controlErr != nil {
+			return controlErr
 		}
 
 		// Need more data.
@@ -147,7 +186,10 @@ func (rb *readBuffer) feedUntilDone(conn net.Conn, feeder streamFeeder, out io.W
 			rb.compact()
 		}
 
-		dl, ok := deadline(wireBytes)
+		dl, ok, _, controlErr := control(wireBytes, consumedBytes)
+		if controlErr != nil {
+			return controlErr
+		}
 		n, err := rb.readMore(conn, dl, ok)
 		wireBytes += n
 		if err != nil {

--- a/reader.go
+++ b/reader.go
@@ -13,8 +13,8 @@ import (
 	"github.com/mnightingale/rapidyenc"
 )
 
-// YEncMeta groups yEnc metadata fields available from =ybegin and =ypart headers,
-// populated before body decoding begins.
+// YEncMeta groups provisional yEnc metadata from =ybegin and =ypart. It is
+// available before decoding completes and is not final integrity evidence.
 type YEncMeta struct {
 	FileName  string
 	FileSize  int64
@@ -40,10 +40,13 @@ type NNTPResponse struct {
 	eof          bool
 	body         bool
 	hasPart      bool
+	hasBegin     bool
 	hasEnd       bool
 	hasCrc       bool
 	hasEmptyline bool // for article requests has the empty line separating headers and body been seen
 	onMeta       func(YEncMeta)
+	headerErr    error
+	decodeFn     func(dst, src []byte, state *rapidyenc.State) (nDst, nSrc int, end rapidyenc.End, err error)
 }
 
 const nntpBody = 222
@@ -268,7 +271,14 @@ func (r *NNTPResponse) decodeYenc(buf []byte, out io.Writer) (n int64, err error
 	var produced, consumed int
 	var end rapidyenc.End
 
-	produced, consumed, end, _ = rapidyenc.DecodeIncremental(buf, buf, &r.State)
+	decodeFn := r.decodeFn
+	if decodeFn == nil {
+		decodeFn = rapidyenc.DecodeIncremental
+	}
+	produced, consumed, end, err = decodeFn(buf, buf, &r.State)
+	if err != nil {
+		return 0, fmt.Errorf("%w: yEnc decode: %w", ErrBodyCorrupt, err)
+	}
 
 	if produced > 0 {
 		r.CRC = crc32.Update(r.CRC, crc32.IEEETable, buf[:produced])
@@ -302,10 +312,18 @@ func (r *NNTPResponse) decodeYenc(buf []byte, out io.Writer) (n int64, err error
 func (r *NNTPResponse) processYencHeader(line []byte) {
 	var err error
 	if bytes.HasPrefix(line, []byte("=ybegin ")) {
+		r.hasBegin = true
 		line = line[len("=ybegin"):]
-		r.YEnc.FileSize, _ = extractInt(line, []byte(" size="))
-		r.YEnc.FileName, _ = extractString(line, []byte(" name="))
+		if r.YEnc.FileSize, err = extractInt(line, []byte(" size=")); err != nil {
+			r.headerErr = fmt.Errorf("invalid =ybegin size: %w", err)
+		}
+		if r.YEnc.FileName, err = extractString(line, []byte(" name=")); err != nil {
+			r.headerErr = fmt.Errorf("invalid =ybegin name: %w", err)
+		}
 		if r.YEnc.Part, err = extractInt(line, []byte(" part=")); err != nil {
+			if bytes.Contains(line, []byte(" part=")) {
+				r.headerErr = fmt.Errorf("invalid =ybegin part: %w", err)
+			}
 			// Not multi-part, so body starts immediately after =ybegin
 			r.body = true
 			r.YEnc.PartSize = r.YEnc.FileSize
@@ -314,7 +332,9 @@ func (r *NNTPResponse) processYencHeader(line []byte) {
 				r.onMeta = nil
 			}
 		}
-		r.YEnc.Total, _ = extractInt(line, []byte(" total="))
+		if r.YEnc.Total, err = extractInt(line, []byte(" total=")); err != nil && bytes.Contains(line, []byte(" total=")) {
+			r.headerErr = fmt.Errorf("invalid =ybegin total: %w", err)
+		}
 	} else if bytes.HasPrefix(line, []byte("=ypart ")) {
 		// =ypart signals start of body data in multi-part files
 		r.hasPart = true
@@ -322,11 +342,15 @@ func (r *NNTPResponse) processYencHeader(line []byte) {
 		line = line[len("=ypart"):]
 		var begin int64
 		// Convert from 1-based to 0-based indexing
-		if begin, err = extractInt(line, []byte(" begin=")); err == nil {
+		if begin, err = extractInt(line, []byte(" begin=")); err != nil || begin <= 0 {
+			r.headerErr = fmt.Errorf("invalid =ypart begin")
+		} else {
 			r.YEnc.PartBegin = begin - 1
 		}
-		if end, err := extractInt(line, []byte(" end=")); err == nil && end > begin {
+		if end, endErr := extractInt(line, []byte(" end=")); endErr == nil && end >= begin && begin > 0 {
 			r.YEnc.PartSize = end - r.YEnc.PartBegin
+		} else {
+			r.headerErr = fmt.Errorf("invalid =ypart end")
 		}
 		if r.onMeta != nil {
 			r.onMeta(r.YEnc)
@@ -342,8 +366,63 @@ func (r *NNTPResponse) processYencHeader(line []byte) {
 			r.ExpectedCRC = crc
 			r.hasCrc = true
 		}
-		r.EndSize, _ = extractInt(line, []byte(" size="))
+		if (bytes.Contains(line, []byte(" pcrc32=")) || bytes.Contains(line, []byte(" crc32="))) && !r.hasCrc {
+			r.headerErr = fmt.Errorf("invalid =yend CRC")
+		}
+		if r.EndSize, err = extractInt(line, []byte(" size=")); err != nil {
+			r.headerErr = fmt.Errorf("invalid =yend size: %w", err)
+		}
 	}
+}
+
+// validateBody verifies the framing and integrity facts that are knowable at
+// the transport boundary. It is called before a buffered BODY attempt may be
+// accepted or selected as a provider fallback winner.
+func (r *NNTPResponse) validateBody() error {
+	if r.StatusCode != nntpBody {
+		return nil
+	}
+	if r.Format != rapidyenc.FormatYenc || !r.hasBegin {
+		return fmt.Errorf("%w: missing valid =ybegin", ErrBodyCorrupt)
+	}
+	if r.headerErr != nil {
+		return fmt.Errorf("%w: %v", ErrBodyCorrupt, r.headerErr)
+	}
+	if !r.hasEnd {
+		return fmt.Errorf("%w: missing =yend", ErrBodyCorrupt)
+	}
+	if r.YEnc.FileSize < 0 || r.YEnc.PartSize < 0 || r.YEnc.PartBegin < 0 {
+		return fmt.Errorf("%w: negative yEnc metadata", ErrBodyCorrupt)
+	}
+	if r.YEnc.FileName == "" {
+		return fmt.Errorf("%w: missing yEnc name", ErrBodyCorrupt)
+	}
+	if r.hasPart && r.YEnc.Part <= 0 {
+		return fmt.Errorf("%w: =ypart without valid part number", ErrBodyCorrupt)
+	}
+	if r.YEnc.Part > 0 {
+		if !r.hasPart {
+			return fmt.Errorf("%w: multipart body missing =ypart", ErrBodyCorrupt)
+		}
+		if r.YEnc.Total <= 0 || r.YEnc.Part > r.YEnc.Total {
+			return fmt.Errorf("%w: part exceeds total", ErrBodyCorrupt)
+		}
+		partEnd := r.YEnc.PartBegin + r.YEnc.PartSize
+		if r.YEnc.PartSize != int64(r.BytesDecoded) || partEnd > r.YEnc.FileSize ||
+			(r.YEnc.Part == r.YEnc.Total && partEnd != r.YEnc.FileSize) ||
+			(r.YEnc.Part < r.YEnc.Total && partEnd >= r.YEnc.FileSize) {
+			return fmt.Errorf("%w: incoherent multipart size", ErrBodyCorrupt)
+		}
+	} else if r.YEnc.FileSize != int64(r.BytesDecoded) {
+		return fmt.Errorf("%w: decoded size %d does not match file size %d", ErrBodyCorrupt, r.BytesDecoded, r.YEnc.FileSize)
+	}
+	if r.EndSize != int64(r.BytesDecoded) {
+		return fmt.Errorf("%w: trailer size %d does not match decoded size %d", ErrBodyCorrupt, r.EndSize, r.BytesDecoded)
+	}
+	if r.hasCrc && r.CRC != r.ExpectedCRC {
+		return fmt.Errorf("%w: %w", ErrBodyCorrupt, ErrCRCMismatch)
+	}
+	return nil
 }
 
 func extractString(data, substr []byte) (string, error) {

--- a/speedtest.go
+++ b/speedtest.go
@@ -15,9 +15,9 @@ const DefaultSpeedTestNZBURL = "https://sabnzbd.org/tests/test_download_1GB.nzb"
 
 // SpeedTestOptions configures a speed test run.
 type SpeedTestOptions struct {
-	NZBURL          string        // defaults to DefaultSpeedTestNZBURL
-	NZBReader       io.Reader     // overrides NZBURL when set (for tests/local files)
-	MaxSegments     int           // 0 = all
+	NZBURL          string    // defaults to DefaultSpeedTestNZBURL
+	NZBReader       io.Reader // overrides NZBURL when set (for tests/local files)
+	MaxSegments     int       // 0 = all
 	OnProgress      func(SpeedTestProgress)
 	NZBFetchTimeout time.Duration // defaults to 30s
 	ProviderName    string        // if set, test only this provider
@@ -102,7 +102,7 @@ func (c *Client) SpeedTest(ctx context.Context, opts SpeedTestOptions) (*SpeedTe
 				elapsed := time.Since(start)
 				secs := elapsed.Seconds()
 
-				instantaneous := float64(wireNow-lastWireBytes) // 1s tick
+				instantaneous := float64(wireNow - lastWireBytes) // 1s tick
 				lastWireBytes = wireNow
 
 				var avg float64
@@ -256,11 +256,11 @@ func (c *Client) sendToGroup(ctx context.Context, g *providerGroup, payload []by
 	return outerCh
 }
 
-// findGroup searches mainGroups and backupGroups by name.
+// findGroup searches mainGroups and backupGroups by resolved name or stable ID.
 func (c *Client) findGroup(name string) *providerGroup {
 	for _, gs := range []*[]*providerGroup{c.mainGroups.Load(), c.backupGroups.Load()} {
 		for _, g := range *gs {
-			if g.name == name {
+			if g.name == name || g.id == name {
 				return g
 			}
 		}

--- a/stat.go
+++ b/stat.go
@@ -132,7 +132,7 @@ func (c *Client) statOne(ctx context.Context, messageID string, target *provider
 // resilient single-group send (with fresh-connection retry on connection death)
 // that the failover path uses per provider. No cross-provider failover.
 func (c *Client) statViaGroup(ctx context.Context, g *providerGroup, payload []byte, priority bool) Response {
-	resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, nil, nil, priority)
+	resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, nil, nil, priority, false, false)
 	switch {
 	case cancelled:
 		err := ctx.Err()

--- a/stat_pipeline_test.go
+++ b/stat_pipeline_test.go
@@ -142,7 +142,7 @@ func TestStatInflight_BodyBounded(t *testing.T) {
 						<-release
 						atomic.AddInt32(&cur, -1)
 						wmu.Lock()
-						_, _ = server.Write([]byte("222 0 <x@h> body follows\r\n.\r\n"))
+						_, _ = server.Write(yencSinglePart([]byte("x"), "x.bin"))
 						wmu.Unlock()
 					}()
 				}


### PR DESCRIPTION
## Summary

- make abandoned BODY cleanup byte/time bounded, commit prebuffered decoded output, and retire unsafe sockets
- add stable provider IDs, typed outcomes, structured errors, ordered attempt evidence, dual-clock timing, and targeted fresh-transport BODY
- normalize 423/430, retry 451 once on a fresh connection, preserve provider order through parallel STAT probes, and continue buffered corruption fallback
- require complete yEnc framing, coherent metadata/sizes, native decoder success, and every supplied CRC before buffered BODY acceptance
- make unsent priority strict and expose configurable ordinary STAT occupancy plus priority headroom
- preserve raw Send behavior and existing errors.Is sentinel checks for v4 callers

## Regression baseline

The first development commit is tests-only. Against unmodified v4.13.0 it reproduced prebuffered commitment failure, writer-error socket reuse, unbounded canceled pipeline drains at depths 1/4/10, missing 423/451 fallback, mixed 430/451 becoming missing, corruption/truncation acceptance, and missing provider/attempt evidence.

## Verification

- `make check` with Go 1.26.0: generate, tidy, golangci-lint (0 issues), and `go test -race ./...`
- focused PR1 deterministic suite: 10 consecutive passes
- deterministic drain-cap benchmark across 64 KiB/256 KiB/1 MiB and 50/100/250 ms candidates
- AltMount plan-relevant linked packages pass against this branch
- every AltMount package compiles against the additive v4 API

No live-provider credentials, message IDs, NZBs, databases, or live evidence were used. Circuit-breaker behavior remains intentionally scoped to the follow-up nntppool PR2.