### PR TITLE
feat: skip same-storage providers after 430 via StorageGroup

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -481,7 +481,7 @@ func TestClient_SendRetryFallbackBackup(t *testing.T) {
 	}
 
 	c, err := NewClient(context.Background(), []Provider{
-		{Factory: makeFactory(430), Connections: 1},        // main: always 430
+		{Factory: makeFactory(430), Connections: 1},               // main: always 430
 		{Factory: makeFactory(223), Connections: 1, Backup: true}, // backup: 223
 	})
 	if err != nil {
@@ -804,7 +804,6 @@ func TestClient_FIFODispatch(t *testing.T) {
 		t.Errorf("FIFO: p1=%d p2=%d, want p1=%d p2=0", hits["p1"], hits["p2"], N)
 	}
 }
-
 
 func TestClient_FIFO430Fallthrough(t *testing.T) {
 	// Provider #1 returns 430, provider #2 returns 223.
@@ -1314,8 +1313,8 @@ func TestClient_502CommandFallsBackToBackup(t *testing.T) {
 	}
 
 	c, err := NewClient(context.Background(), []Provider{
-		{Factory: makeFactory(502), Connections: 1},                // main: always 502
-		{Factory: makeFactory(223), Connections: 1, Backup: true},  // backup: success
+		{Factory: makeFactory(502), Connections: 1},               // main: always 502
+		{Factory: makeFactory(223), Connections: 1, Backup: true}, // backup: success
 	})
 	if err != nil {
 		t.Fatalf("NewClient() error = %v", err)
@@ -1447,3 +1446,106 @@ func TestKeepalive_DeadConnection(t *testing.T) {
 	}
 }
 
+func TestClient_Skip430SameStorageGroup(t *testing.T) {
+	// Two providers on different hosts that resell the same upstream storage.
+	// A 430 from the first means the second holds the same article set, so it
+	// should be skipped.
+	var counts [2]atomic.Int64
+	make430Factory := func(idx int) ConnFactory {
+		return func(ctx context.Context) (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				_, _ = server.Write([]byte("200 server ready\r\n"))
+				buf := make([]byte, 4096)
+				for {
+					n, err := server.Read(buf)
+					if err != nil {
+						return
+					}
+					if bytes.Contains(buf[:n], []byte("STAT")) {
+						counts[idx].Add(1)
+					}
+					_, _ = server.Write([]byte("430 no such article\r\n"))
+				}
+			}()
+			return client, nil
+		}
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Host: "news1.example.com:563", StorageGroup: "backbone-a", Factory: make430Factory(0), Connections: 1},
+		{Host: "news2.example.com:563", StorageGroup: "backbone-a", Factory: make430Factory(1), Connections: 1},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp := <-c.Send(ctx, []byte("STAT <id@test>\r\n"), nil)
+	if resp.StatusCode != 430 {
+		t.Fatalf("StatusCode = %d, want 430", resp.StatusCode)
+	}
+
+	// Dispatch picks the starting provider, so assert on the total rather than
+	// which one went first: exactly one of the pair may be tried.
+	if got := counts[0].Load() + counts[1].Load(); got != 1 {
+		t.Errorf("requests = [%d, %d], total %d, want exactly 1 (same StorageGroup should be skipped)",
+			counts[0].Load(), counts[1].Load(), got)
+	}
+}
+
+func TestClient_Skip430StorageGroupDoesNotSkipOtherGroups(t *testing.T) {
+	// Two mains sharing a group, plus a backup on its own storage. The grouped
+	// main is skipped after the first 430, but the independent backup must still
+	// be tried — that provider is the only one that can hold a different answer.
+	var counts [3]atomic.Int64
+	make430Factory := func(idx int) ConnFactory {
+		return func(ctx context.Context) (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				_, _ = server.Write([]byte("200 server ready\r\n"))
+				buf := make([]byte, 4096)
+				for {
+					n, err := server.Read(buf)
+					if err != nil {
+						return
+					}
+					if bytes.Contains(buf[:n], []byte("STAT")) {
+						counts[idx].Add(1)
+					}
+					_, _ = server.Write([]byte("430 no such article\r\n"))
+				}
+			}()
+			return client, nil
+		}
+	}
+
+	c, err := NewClient(context.Background(), []Provider{
+		{Host: "news1.example.com:563", StorageGroup: "backbone-a", Factory: make430Factory(0), Connections: 1},
+		{Host: "news2.example.com:563", StorageGroup: "backbone-a", Factory: make430Factory(1), Connections: 1},
+		{Host: "news3.example.com:563", StorageGroup: "backbone-b", Factory: make430Factory(2), Connections: 1, Backup: true},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp := <-c.Send(ctx, []byte("STAT <id@test>\r\n"), nil)
+	if resp.StatusCode != 430 {
+		t.Fatalf("StatusCode = %d, want 430", resp.StatusCode)
+	}
+
+	if got := counts[0].Load() + counts[1].Load(); got != 1 {
+		t.Errorf("grouped mains = [%d, %d], total %d, want exactly 1",
+			counts[0].Load(), counts[1].Load(), got)
+	}
+	if counts[2].Load() != 1 {
+		t.Errorf("independent backup requests = %d, want 1 (must not be skipped)", counts[2].Load())
+	}
+}

--- a/nntp.go
+++ b/nntp.go
@@ -1368,6 +1368,7 @@ type Provider struct {
 	StatInflight    int           // 0 defaults to Inflight; deeper pipeline depth for bodyless STAT commands. Because STAT carries no payload, many can be in flight per connection at negligible memory cost, amortising round-trips. Set higher than Inflight (e.g. 50-100) for STAT-heavy workloads without inflating BODY memory.
 	Factory         ConnFactory   // overrides Host/TLSConfig when set
 	Backup          bool          // if true, only used when main providers return 430
+	StorageGroup    string        // optional label for providers sharing upstream storage (same backbone); a 430 from one skips the rest in the group for that request
 	SkipPing        bool          // if true, skip the DATE ping on startup (for providers that don't support DATE)
 	IdleTimeout     time.Duration // 0 means no idle disconnect
 	ThrottleRestore time.Duration // 0 defaults to 30s
@@ -1426,6 +1427,7 @@ type Provider struct {
 type providerGroup struct {
 	name      string
 	host      string // raw Provider.Host; empty for Factory-based providers
+	skipID    string // Provider.StorageGroup when set, else host; identity used for 430 skipping
 	maxConns  int
 	ctx       context.Context // cancelled on removal/close
 	reqCh     chan *Request
@@ -1637,6 +1639,7 @@ func (c *Client) startProviderGroup(p Provider, index int) *providerGroup {
 	g := &providerGroup{
 		name:        name,
 		host:        p.Host,
+		skipID:      providerSkipID(p),
 		maxConns:    p.Connections,
 		ctx:         gctx,
 		reqCh:       make(chan *Request, p.Connections),
@@ -1880,7 +1883,7 @@ func (c *Client) raceCandidates(
 	live := make([]*providerGroup, 0, len(candidates))
 	seen := make(map[string]bool)
 	for _, g := range candidates {
-		if hostSkipped(g.host, skipHosts, *skipCount) {
+		if hostSkipped(g.skipID, skipHosts, *skipCount) {
 			continue
 		}
 		if g.isQuotaExceeded() {
@@ -1921,8 +1924,8 @@ func (c *Client) raceCandidates(
 			return false, false, fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
 		}
 		if resp.StatusCode == 430 || resp.StatusCode == 423 {
-			if g.host != "" && *skipCount < len(skipHosts) {
-				skipHosts[*skipCount] = g.host
+			if g.skipID != "" && *skipCount < len(skipHosts) {
+				skipHosts[*skipCount] = g.skipID
 				*skipCount++
 			}
 			c.nextIdx.Add(1)
@@ -1966,8 +1969,8 @@ func (c *Client) raceCandidates(
 			}
 			lastErr = fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
 		case 430, 423:
-			if g.host != "" && *skipCount < len(skipHosts) {
-				skipHosts[*skipCount] = g.host
+			if g.skipID != "" && *skipCount < len(skipHosts) {
+				skipHosts[*skipCount] = g.skipID
 				*skipCount++
 			}
 			c.nextIdx.Add(1)
@@ -2008,8 +2011,8 @@ func (c *Client) raceCandidates(
 	}
 	if resp.StatusCode == 430 || resp.StatusCode == 423 {
 		// Rare: article expired between STAT and BODY.
-		if winner.host != "" && *skipCount < len(skipHosts) {
-			skipHosts[*skipCount] = winner.host
+		if winner.skipID != "" && *skipCount < len(skipHosts) {
+			skipHosts[*skipCount] = winner.skipID
 			*skipCount++
 		}
 		c.nextIdx.Add(1)
@@ -2135,8 +2138,19 @@ func (c *Client) tryGroup(
 	}
 }
 
-// hostSkipped reports whether host is already in the skip list.
-// Empty hosts (Factory-based providers) are never skipped.
+// providerSkipID returns the identity used to suppress further attempts after a
+// 430. Providers on the same host share article availability; so do providers
+// that resell the same upstream storage under different hostnames (e.g. two
+// brands on one backbone). StorageGroup lets an operator declare the latter.
+func providerSkipID(p Provider) string {
+	if p.StorageGroup != "" {
+		return p.StorageGroup
+	}
+	return p.Host
+}
+
+// hostSkipped reports whether the skip identity is already in the skip list.
+// Empty identities (Factory-based providers with no StorageGroup) are never skipped.
 func hostSkipped(host string, skipHosts *[4]string, count int) bool {
 	if host == "" || count == 0 {
 		return false
@@ -2262,8 +2276,9 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 	var lastErr error
 	post430 := false
 
-	// Track hosts that returned 430 so we can skip other providers on
-	// the same server (different credentials won't help).
+	// Track providers that returned 430 so we can skip others sharing the same
+	// article availability — same host (different credentials won't help), or
+	// same declared StorageGroup (same upstream storage behind another brand).
 	var skipHosts [4]string
 	skipCount := 0
 
@@ -2304,7 +2319,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 	for attempt := range n {
 		idx := (start + attempt) % n
 		g := mains[idx]
-		if hostSkipped(g.host, &skipHosts, skipCount) {
+		if hostSkipped(g.skipID, &skipHosts, skipCount) {
 			continue
 		}
 		if g.isQuotaExceeded() {
@@ -2347,8 +2362,8 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 		}
 		if resp.StatusCode == 430 {
 			c.nextIdx.Add(1) // bias next request away from this provider
-			if g.host != "" && skipCount < len(skipHosts) {
-				skipHosts[skipCount] = g.host
+			if g.skipID != "" && skipCount < len(skipHosts) {
+				skipHosts[skipCount] = g.skipID
 				skipCount++
 			}
 			lastResp = resp
@@ -2412,7 +2427,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 	} else {
 		for i := range backups {
 			g := backups[i]
-			if hostSkipped(g.host, &skipHosts, skipCount) {
+			if hostSkipped(g.skipID, &skipHosts, skipCount) {
 				continue
 			}
 			if g.isQuotaExceeded() {


### PR DESCRIPTION
Providers on the same host are already skipped once one returns 430 — different credentials to the same server cannot yield a different article. The same reasoning applies one level up: two providers reselling the same upstream storage under different hostnames share an article set, so trying the second after the first returns 430 is a guaranteed-useless round trip.

Backbone membership cannot be reliably derived from a hostname and changes over time, so it is declared rather than inferred. Set `StorageGroup` to the same value on providers that share upstream storage:

```go
{Host: "news.brand-a.com", StorageGroup: "backbone-x"},
{Host: "news.brand-b.com", StorageGroup: "backbone-x"},
{Host: "news.other.net",   Backup: true},   // independent; still tried
```

Empty `StorageGroup` (the default) preserves existing behaviour exactly — the skip identity falls back to `Host`, so this is a no-op for every current user.

### Why it matters

The common case is an operator holding accounts with two brands on one backbone plus a genuine third-party backup. Today every missing article costs a redundant query to the second brand before the backup is reached — which both wastes a round trip and delays the only provider that could answer differently.

On the setup that prompted this, 83% of import failures are missing articles across ~1,475 imports, and two of three configured providers share a backbone.

### Implementation

`g.host` becomes `g.skipID` at the existing skip sites; `providerSkipID()` returns `StorageGroup` when set, else `Host`. No change to the skip-list mechanics or `[4]string` bound.

### Tests

- `TestClient_Skip430SameStorageGroup` — grouped peer is skipped
- `TestClient_Skip430StorageGroupDoesNotSkipOtherGroups` — an independent backup is still tried

Both fail if `providerSkipID` ignores `StorageGroup`, and the existing `Skip430*` tests still pass.