### PR TITLE
fix: zero-byte reads always carry a deadline — keepalive/POST could park a connection forever

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mnightingale/rapidyenc"
 )
@@ -383,12 +384,16 @@ func (c *Client) doSendPost(ctx context.Context, payloadBody io.Reader, respCh c
 		idx := (start + attempt) % n
 		g := mains[idx]
 		innerCh := make(chan Response, 1)
+		// attemptDeadline is what bounds the pre-first-byte read: with a
+		// cancel-only caller context and a server that never answers the POST,
+		// a deadline-less request would block the reader in Read forever.
 		req := &Request{
-			Ctx:         ctx,
-			Payload:     []byte("POST\r\n"),
-			RespCh:      innerCh,
-			PayloadBody: payloadBody,
-			PostMode:    true,
+			Ctx:             ctx,
+			Payload:         []byte("POST\r\n"),
+			RespCh:          innerCh,
+			PayloadBody:     payloadBody,
+			PostMode:        true,
+			attemptDeadline: time.Now().Add(g.attemptTimeout()),
 		}
 
 		// Try hot channel first (non-blocking), then cold channel.

--- a/integration_test.go
+++ b/integration_test.go
@@ -1446,6 +1446,44 @@ func TestKeepalive_DeadConnection(t *testing.T) {
 	}
 }
 
+// TestKeepalive_SilentServer verifies the probe cannot park the connection:
+// a server that ACCEPTS the keepalive command but never answers (half-open
+// connection, stale provider session) must be detected via the probe's
+// attempt deadline — Run() returns so the pool replaces the connection.
+// Without the deadline the reader blocks in a deadline-less Read forever,
+// holding the connection slot and the provider session indefinitely.
+func TestKeepalive_SilentServer(t *testing.T) {
+	conn := mockServer(t, func(s net.Conn) {
+		_, _ = s.Write([]byte("200 server ready\r\n"))
+
+		buf := make([]byte, 256)
+		for {
+			// Read commands and never respond — the silent half-open server.
+			if _, err := s.Read(buf); err != nil {
+				return
+			}
+		}
+	})
+
+	reqCh := make(chan *Request)
+	nc, err := newNNTPConnectionFromConn(context.Background(), conn, 1, reqCh, nil, Auth{}, "", nil, nil)
+	if err != nil {
+		t.Fatalf("newNNTPConnectionFromConn() error = %v", err)
+	}
+	nc.keepaliveInterval = 20 * time.Millisecond
+	nc.keepaliveCommand = "DATE"
+	nc.stallTimeout = 100 * time.Millisecond // bounds the probe via keepaliveProbeTimeout
+
+	go nc.Run()
+
+	select {
+	case <-nc.Done():
+		// Good: the probe deadline expired, the connection closed, Run() returned.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: a silent server parked the keepalive probe — Run() never returned")
+	}
+}
+
 func TestClient_Skip430SameStorageGroup(t *testing.T) {
 	// Two providers on different hosts that resell the same upstream storage.
 	// A 430 from the first means the second holds the same article set, so it

--- a/nntp.go
+++ b/nntp.go
@@ -368,6 +368,17 @@ func safeClose[T any](ch chan T) {
 	close(ch)
 }
 
+// keepaliveProbeTimeout bounds a keepalive probe's round trip. The probe is a
+// trivial command (DATE/HELP), so the connection's stall timeout is ample as a
+// time-to-first-byte bound; with stall disabled, a fixed 30s fallback still
+// guarantees the probe can never park the connection forever.
+func (c *NNTPConnection) keepaliveProbeTimeout() time.Duration {
+	if c.stallTimeout > 0 {
+		return c.stallTimeout
+	}
+	return 30 * time.Second
+}
+
 // keepaliveExpectedCode returns the expected NNTP status code for the given
 // keepalive command: DATE→111, HELP→100, CAPABILITIES→101, default→111.
 func keepaliveExpectedCode(cmd string) int {
@@ -955,10 +966,20 @@ mainLoop:
 		if didKeepalive {
 			keepaliveCh = time.After(c.keepaliveInterval) // reset regardless of outcome
 			kaCh := make(chan Response, 1)
+			// The probe MUST carry an attempt deadline: with a background context
+			// and no deadline, a server that accepts the command but never
+			// answers (half-open connection, stale provider session) leaves the
+			// reader in a deadline-less Read forever — the connection parks
+			// "busy" holding its slot and its provider session, and the feature
+			// meant to detect dead connections becomes the thing that wedges
+			// them. On expiry the reader surfaces a timeout, closes the
+			// connection, and the pool replaces it — exactly what a keepalive
+			// is for.
 			kaReq := &Request{
-				Payload: []byte(c.keepaliveCommand + "\r\n"),
-				RespCh:  kaCh,
-				Ctx:     context.Background(),
+				Payload:         []byte(c.keepaliveCommand + "\r\n"),
+				RespCh:          kaCh,
+				Ctx:             context.Background(),
+				attemptDeadline: time.Now().Add(c.keepaliveProbeTimeout()),
 			}
 			if _, err := bw.Write(kaReq.Payload); err != nil {
 				_ = c.conn.Close()


### PR DESCRIPTION
Fixes #77.

Two request-construction sites reach the reader with no `attemptDeadline` and a deadline-less context, so the pre-first-byte read has **no deadline at all** (the stall timer only arms once bytes flow):

1. **The keepalive probe** (`Ctx: context.Background()`, no attemptDeadline) — a server that accepts the command but never answers (half-open connection, stale provider session) leaves the reader blocked in `Read` forever and the writer blocked on `kaCh`, holding the connection slot and the provider account session indefinitely. The feature meant to detect dead connections becomes the thing that wedges them. We observed this in production against Newshosting: connections progressively parked until zero transfers flowed, while a fresh out-of-process connection got `200 Service Ready` instantly; only force-closing the sockets recovered.
2. **The POST path** (caller ctx, no attemptDeadline) — a cancel-only caller context plus a server that never answers the POST blocks the same way (cancellation only flips delivery to `io.Discard`; it never aborts the read).

### The fix

- The keepalive request carries `attemptDeadline: now + keepaliveProbeTimeout()` (the connection's `stallTimeout` when set — a DATE reply is trivial, so the stall window is ample as a TTFB bound — else a 30s fallback). On expiry the reader surfaces a timeout, closes the connection, and the pool replaces it: exactly what a keepalive exists to do.
- The POST request uses the provider group's existing `attemptTimeout()`, same shape as the article path at `nntp.go:2078`.

### Test

`TestKeepalive_SilentServer` sits between the two existing keepalive tests and covers the parked-probe case: server reads the DATE and stays silent (no close) → `Run()` must return within the probe deadline. It hangs forever without the fix; passes in ~0.12s with it. Full suite passes.

Thanks for the library — it's been rock-solid under heavy load apart from this one leash.