### PR TITLE
Escalate the attempt window when every provider expired awaiting its first response byte; typed attempt-timeout errors

### DIFF
--- a/attempt_escalation_test.go
+++ b/attempt_escalation_test.go
@@ -1,0 +1,148 @@
+package nntppool
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// slowStatusFactory returns a healthy server that answers every BODY with a
+// 430 — after `delay`. This is the real-world slow-spool-lookup shape: aged
+// articles have been measured taking ~7.5s to a 430 on a healthy Newshosting
+// connection while the TTFB EWMA (cache-hot serving) derives a 2s window.
+func slowStatusFactory(delay time.Duration, dials *atomic.Int64) ConnFactory {
+	return func(ctx context.Context) (net.Conn, error) {
+		if dials != nil {
+			dials.Add(1)
+		}
+		client, server := net.Pipe()
+		go func() {
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			// The read loop never blocks on answering: each BODY is answered
+			// from its own goroutine after `delay`, exactly like a real server
+			// whose spool lookup runs while the connection stays responsive.
+			// (net.Pipe is unbuffered — a server that sleeps inline would
+			// deadlock a client command against its own pending answer.)
+			var wmu sync.Mutex
+			for {
+				n, err := server.Read(buf)
+				if err != nil {
+					return
+				}
+				if strings.HasPrefix(string(buf[:n]), "BODY") {
+					go func() {
+						time.Sleep(delay)
+						wmu.Lock()
+						defer wmu.Unlock()
+						_, _ = server.Write([]byte("430 No Such Article\r\n"))
+					}()
+				}
+			}
+		}()
+		return client, nil
+	}
+}
+
+// TestSlowStatusLineEscalates: a server needing longer than the attempt window
+// to produce its status line must eventually be HEARD, not abandoned forever.
+// With base 200ms the escalation ladder is 200→400→800ms; a 300ms-delayed 430
+// fails the base attempt and is delivered by an escalated one. Before
+// escalation this request could never complete at any retry count: every
+// attempt re-asked the same question with the same too-short window.
+func TestSlowStatusLineEscalates(t *testing.T) {
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: slowStatusFactory(300*time.Millisecond, nil), Connections: 1, SkipPing: true, AttemptTimeout: 200 * time.Millisecond},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	start := time.Now()
+	_, err = c.Body(context.Background(), "aged@spool")
+	elapsed := time.Since(start)
+
+	// The contract under test is DELIVERY: before escalation this request
+	// could never complete at any retry count (every attempt re-asked with the
+	// same too-short window). Exact timing is internal; boundedness is not.
+	if !errors.Is(err, ErrArticleNotFound) {
+		t.Fatalf("Body() error = %v, want ErrArticleNotFound (the slow 430 must be delivered, not abandoned)", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("elapsed = %v, want well under 5s", elapsed)
+	}
+}
+
+// TestExpiredAttemptsKeepTheirReason: when every attempt expires, the terminal
+// error must carry the attempt-timeout story — the bare "all providers
+// exhausted" reads as total infrastructure death and once cost a 17-hour
+// misdiagnosis chasing dead sockets and session caps.
+func TestExpiredAttemptsKeepTheirReason(t *testing.T) {
+	hung := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			_, _ = server.Read(buf) // swallow the command, never answer
+			<-ctx.Done()
+			_ = server.Close()
+		}()
+		return client, nil
+	}
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: hung, Connections: 1, SkipPing: true, AttemptTimeout: 100 * time.Millisecond},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	_, err = c.Body(context.Background(), "id@test")
+	if err == nil {
+		t.Fatal("Body() = nil error, want attempt-timeout failure")
+	}
+	var at *AttemptTimeoutError
+	if !errors.As(err, &at) {
+		t.Fatalf("Body() error = %v, want it to wrap *AttemptTimeoutError (never the bare exhausted form)", err)
+	}
+	if at.Phase != "response" {
+		t.Errorf("AttemptTimeoutError.Phase = %q, want %q", at.Phase, "response")
+	}
+}
+
+// TestEscalationBounded: a hung provider must still fail over in bounded time —
+// base + 2× + 4× windows, never an unbounded ladder.
+func TestEscalationBounded(t *testing.T) {
+	hung := func(ctx context.Context) (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			_, _ = server.Write([]byte("200 ready\r\n"))
+			buf := make([]byte, 4096)
+			_, _ = server.Read(buf)
+			<-ctx.Done()
+			_ = server.Close()
+		}()
+		return client, nil
+	}
+	c, err := NewClient(context.Background(), []Provider{
+		{Factory: hung, Connections: 1, SkipPing: true, AttemptTimeout: 100 * time.Millisecond},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	start := time.Now()
+	_, _ = c.Body(context.Background(), "id@test")
+	elapsed := time.Since(start)
+	// 100+200+400ms of windows plus scheduling slack — nowhere near unbounded.
+	if elapsed > 3*time.Second {
+		t.Errorf("elapsed = %v, want well under 3s (escalation must stay bounded)", elapsed)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,33 @@ package nntppool
 import (
 	"errors"
 	"fmt"
+	"time"
 )
+
+// AttemptTimeoutError reports an attempt that expired inside its attempt
+// window: either it could not be dispatched to a connection ("dispatch"
+// phase — the provider is saturated) or it was sent and no first response
+// byte arrived ("response" phase — a hung connection, or a server taking
+// longer than the window to answer; slow spool lookups for aged articles
+// have been measured at ~7.5s to a 430 on a healthy connection). Typed so
+// retry logic can escalate the window on response-phase expiry, and so the
+// terminal "all providers exhausted" error names what actually happened
+// instead of arriving bare.
+type AttemptTimeoutError struct {
+	Provider string
+	Timeout  time.Duration
+	Phase    string // "dispatch" | "response"
+	Cause    error  // the transport-level error, when the connection's own read deadline noticed first
+}
+
+func (e *AttemptTimeoutError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: attempt expired after %s awaiting %s (%v)", e.Provider, e.Timeout, e.Phase, e.Cause)
+	}
+	return fmt.Sprintf("%s: attempt expired after %s awaiting %s", e.Provider, e.Timeout, e.Phase)
+}
+
+func (e *AttemptTimeoutError) Unwrap() error { return e.Cause }
 
 // Error represents an NNTP protocol-level error with a status code.
 type Error struct {

--- a/nntp.go
+++ b/nntp.go
@@ -71,6 +71,15 @@ const (
 	// retry uses a fresh connection on the same provider.
 	maxConnDiedRetries = 2
 
+	// maxAttemptEscalations bounds same-provider retries of a response-phase
+	// attempt expiry, doubling the window each time (base → 2× → 4×, capped at
+	// maxAttemptTimeout): at the 2s adaptive floor that is 2s+4s+8s = 14s of
+	// patience before failing over, which clears real-world slow spool lookups
+	// (~7.5s to a 430 for aged articles) without any new configuration. An
+	// explicit Provider.AttemptTimeout at or above maxAttemptTimeout leaves no
+	// room to grow, so escalation is a no-op there by construction.
+	maxAttemptEscalations = 2
+
 	// minAttemptTimeout is the floor (and default) for the per-attempt timeout
 	// that bounds dispatch + time-to-first-response-byte. Once response bytes
 	// start flowing, the rolling stall timeout takes over instead.
@@ -1932,6 +1941,9 @@ func (c *Client) raceCandidates(
 			return false, true, lastErr
 		}
 		if !ok {
+			if resp.Err != nil {
+				lastErr = resp.Err // expired attempts keep their reason
+			}
 			return false, false, lastErr
 		}
 		if resp.Err != nil {
@@ -2088,10 +2100,24 @@ func (c *Client) tryGroup(
 	onMeta func(YEncMeta),
 	priority bool,
 ) (resp Response, ok bool, done bool) {
+	return c.tryGroupTimeout(ctx, g, payload, bodyWriter, onMeta, priority, g.attemptTimeout())
+}
+
+// tryGroupTimeout is tryGroup with an explicit attempt window — the seam that
+// lets tryGroupResilient escalate the window on response-phase expiry instead
+// of abandoning a slow-but-honest server at the adaptive default.
+func (c *Client) tryGroupTimeout(
+	ctx context.Context,
+	g *providerGroup,
+	payload []byte,
+	bodyWriter io.Writer,
+	onMeta func(YEncMeta),
+	priority bool,
+	attemptTimeout time.Duration,
+) (resp Response, ok bool, done bool) {
 	reqCtx, reqCancel := context.WithCancel(ctx)
 	defer reqCancel()
 
-	attemptTimeout := g.attemptTimeout()
 	innerCh := make(chan Response, 1)
 	req := &Request{
 		Ctx:             reqCtx,
@@ -2127,8 +2153,9 @@ func (c *Client) tryGroup(
 			return Response{}, false, false
 		case <-timer.C:
 			// Could not be dispatched within the attempt window: the provider
-			// is saturated. Fail over.
-			return Response{}, false, false
+			// is saturated. Fail over — with the reason preserved, so the
+			// terminal error names the saturation instead of arriving bare.
+			return Response{Err: &AttemptTimeoutError{Provider: g.name, Timeout: attemptTimeout, Phase: "dispatch"}}, false, false
 		case coldCh <- req:
 		}
 	}
@@ -2146,11 +2173,15 @@ func (c *Client) tryGroup(
 		case <-timer.C:
 			if req.attemptState.CompareAndSwap(attemptPending, attemptAbandoned) {
 				// No response byte arrived in time: hung or too-slow to start.
-				// Cancel so the reader drops the request, and fail over.
+				// Cancel so the reader drops the request, and fail over. The
+				// typed error both survives into the terminal error and lets
+				// tryGroupResilient escalate the window — this phase cannot
+				// distinguish a hung connection from a server legitimately
+				// taking longer than the window to produce its status line.
 				reqCancel()
 				// done only when the caller's or the pool's context was
 				// cancelled (true shutdown), not on a plain attempt timeout.
-				return Response{}, false, ctx.Err() != nil || c.ctx.Err() != nil
+				return Response{Err: &AttemptTimeoutError{Provider: g.name, Timeout: attemptTimeout, Phase: "response"}}, false, ctx.Err() != nil || c.ctx.Err() != nil
 			}
 			// Reader already committed (first byte arrived): the body is
 			// streaming. Do not fail over; keep waiting for it to finish. The
@@ -2261,10 +2292,39 @@ func (c *Client) tryGroupResilient(
 	bodyWriter io.Writer,
 	onMeta func(YEncMeta),
 	priority bool,
+	timeoutScale int,
 ) (resp Response, ok bool, cancelled bool) {
+	// timeoutScale widens the attempt window (base → 2× → 4×, capped at
+	// maxAttemptTimeout) on escalation passes — see doSendWithRetry: a pass in
+	// which EVERY provider expired awaiting its first response byte is re-run
+	// with a wider window, because that shape is a slow-but-honest answer
+	// (cold spool lookups for aged articles measure ~7.5s to a 430 while the
+	// TTFB EWMA — dominated by cache-hot serving — derives a 2s window) at
+	// least as often as it is dead infrastructure. Failover order is
+	// untouched: within a pass a quiet provider still costs one base window.
+	timeout := g.attemptTimeout()
+	for range timeoutScale {
+		if next := min(timeout*2, maxAttemptTimeout); next > timeout {
+			timeout = next
+		}
+	}
 	for r := 0; ; r++ {
-		resp, ok, cancelled = c.tryGroup(ctx, g, payload, bodyWriter, onMeta, priority)
-		if cancelled || !ok {
+		resp, ok, cancelled = c.tryGroupTimeout(ctx, g, payload, bodyWriter, onMeta, priority, timeout)
+		if cancelled {
+			return
+		}
+		if expiredAwaitingResponse(resp, ok) {
+			// Normalize both expiry surfaces (the attempt timer, or the
+			// connection's own read deadline racing it) into one shape: a
+			// failover carrying the typed story — never a deliverable
+			// response, never a bare error.
+			var at *AttemptTimeoutError
+			if !errors.As(resp.Err, &at) {
+				resp.Err = &AttemptTimeoutError{Provider: g.name, Timeout: timeout, Phase: "response", Cause: resp.Err}
+			}
+			return resp, false, false
+		}
+		if !ok {
 			return
 		}
 		// If the attempt already streamed bytes into the caller's writer, never
@@ -2279,6 +2339,25 @@ func (c *Client) tryGroupResilient(
 		}
 		return
 	}
+}
+
+// expiredAwaitingResponse reports whether an attempt died awaiting its first
+// response byte — whichever side noticed first: the attempt timer (ok=false,
+// typed error) or the connection's own read deadline (ok=true, a transport
+// timeout on a request whose reader never committed).
+func expiredAwaitingResponse(resp Response, ok bool) bool {
+	if !ok {
+		var at *AttemptTimeoutError
+		return errors.As(resp.Err, &at) && at.Phase == "response"
+	}
+	// Anything short of committed counts: the attempt timer may have CASed
+	// pending→abandoned in the same instant the reader delivered its deadline
+	// error — both interleavings mean "no first byte ever arrived".
+	if resp.Err == nil || resp.Request == nil || resp.Request.attemptState.Load() == attemptCommitted {
+		return false
+	}
+	var ne net.Error
+	return errors.As(resp.Err, &ne) && ne.Timeout()
 }
 
 func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter io.Writer, onMeta func(YEncMeta), respCh chan Response, priority bool) {
@@ -2337,91 +2416,124 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 		}
 	}
 
-	for attempt := range n {
-		idx := (start + attempt) % n
-		g := mains[idx]
-		if hostSkipped(g.skipID, &skipHosts, skipCount) {
-			continue
-		}
-		if g.isQuotaExceeded() {
-			lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
-			continue
-		}
-		resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430)
-		if cancelled {
-			err := ctx.Err()
-			if err == nil {
-				err = c.ctx.Err()
+	// Escalation passes: pass 0 runs every provider at its base attempt window
+	// (a quiet provider costs one window before failover, exactly as before).
+	// Only when a WHOLE pass produced nothing but expired-awaiting-response
+	// failures — the signature of a slow spool lookup, not of dead infra — is
+	// the pass re-run with the window doubled (capped at maxAttemptTimeout),
+	// so a server that needs 7s to say 430 eventually gets heard while a
+	// genuinely hung pool still fails in bounded time.
+	for scale := 0; ; scale++ {
+		sawExpired, sawOther := false, false
+		for attempt := range n {
+			idx := (start + attempt) % n
+			g := mains[idx]
+			if hostSkipped(g.skipID, &skipHosts, skipCount) {
+				continue
 			}
-			respCh <- Response{Err: err}
-			return
-		}
-		if !ok {
-			// Connection died — try next provider.
-			continue
-		}
-		if resp.Err != nil {
-			// A committed attempt with a caller writer already streamed partial
-			// bytes; deliver the error rather than re-streaming into the same
-			// writer on another provider.
-			if bodyWriter != nil && attemptCommittedResp(resp) {
-				respCh <- resp
+			if g.isQuotaExceeded() {
+				lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
+				sawOther = true
+				continue
+			}
+			resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430, scale)
+			if cancelled {
+				err := ctx.Err()
+				if err == nil {
+					err = c.ctx.Err()
+				}
+				respCh <- Response{Err: err}
 				return
 			}
-			lastErr = resp.Err
-			continue
-		}
-		if resp.StatusCode == 502 {
-			// Provider returned "service unavailable" — remove it from the
-			// pool immediately so no further requests are routed to it.
-			_ = c.RemoveProvider(g.name)
-			if g.p.ReconnectDelay > 0 {
-				c.scheduleReconnect(g)
+			if !ok {
+				// Connection died or the attempt window expired — try the next
+				// provider, keeping the reason: an all-attempts-expired request
+				// used to surface as a BARE "all providers exhausted", which
+				// reads as total infrastructure death and hides the one thread
+				// worth pulling (the per-attempt timeout).
+				if resp.Err != nil {
+					lastErr = resp.Err
+				}
+				var at *AttemptTimeoutError
+				if errors.As(resp.Err, &at) && at.Phase == "response" {
+					sawExpired = true
+				} else {
+					sawOther = true
+				}
+				continue
 			}
-			lastErr = fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
-			continue
-		}
-		if resp.StatusCode == 430 {
-			c.nextIdx.Add(1) // bias next request away from this provider
-			if g.skipID != "" && skipCount < len(skipHosts) {
-				skipHosts[skipCount] = g.skipID
-				skipCount++
+			sawOther = true
+			if resp.Err != nil {
+				// A committed attempt with a caller writer already streamed partial
+				// bytes; deliver the error rather than re-streaming into the same
+				// writer on another provider.
+				if bodyWriter != nil && attemptCommittedResp(resp) {
+					respCh <- resp
+					return
+				}
+				lastErr = resp.Err
+				continue
 			}
-			lastResp = resp
-			hasResp = true
-			post430 = true
+			if resp.StatusCode == 502 {
+				// Provider returned "service unavailable" — remove it from the
+				// pool immediately so no further requests are routed to it.
+				_ = c.RemoveProvider(g.name)
+				if g.p.ReconnectDelay > 0 {
+					c.scheduleReconnect(g)
+				}
+				lastErr = fmt.Errorf("%s: %w", g.name, ErrServiceUnavailable)
+				continue
+			}
+			if resp.StatusCode == 430 {
+				c.nextIdx.Add(1) // bias next request away from this provider
+				if g.skipID != "" && skipCount < len(skipHosts) {
+					skipHosts[skipCount] = g.skipID
+					skipCount++
+				}
+				lastResp = resp
+				hasResp = true
+				post430 = true
 
-			if raceable {
-				// Build remaining mains and race them in parallel via STAT.
-				rest := make([]*providerGroup, 0, n-attempt-1)
-				for a := attempt + 1; a < n; a++ {
-					rest = append(rest, mains[(start+a)%n])
-				}
-				delivered, cancelled, raceErr := c.raceCandidates(
-					ctx, rest, statPayload, payload, bodyWriter, onMeta,
-					&skipHosts, &skipCount, respCh,
-				)
-				if cancelled {
-					err := ctx.Err()
-					if err == nil {
-						err = c.ctx.Err()
+				if raceable {
+					// Build remaining mains and race them in parallel via STAT.
+					rest := make([]*providerGroup, 0, n-attempt-1)
+					for a := attempt + 1; a < n; a++ {
+						rest = append(rest, mains[(start+a)%n])
 					}
-					respCh <- Response{Err: err}
-					return
+					delivered, cancelled, raceErr := c.raceCandidates(
+						ctx, rest, statPayload, payload, bodyWriter, onMeta,
+						&skipHosts, &skipCount, respCh,
+					)
+					if cancelled {
+						err := ctx.Err()
+						if err == nil {
+							err = c.ctx.Err()
+						}
+						respCh <- Response{Err: err}
+						return
+					}
+					if delivered {
+						return
+					}
+					if raceErr != nil {
+						lastErr = raceErr
+					}
+					break // all remaining mains were probed in the race
 				}
-				if delivered {
-					return
-				}
-				if raceErr != nil {
-					lastErr = raceErr
-				}
-				break // all remaining mains were probed in the race
+				continue
 			}
-			continue
+			// Success.
+			respCh <- resp
+			return
 		}
-		// Success.
-		respCh <- resp
-		return
+		// Escalate only on the pure slow-lookup signature: every attempted
+		// provider expired awaiting its first response byte. Any other outcome
+		// (430, quota, conn death, saturation) means the pass learned
+		// something and the normal flow — backups, then the terminal error —
+		// proceeds at once.
+		if !sawExpired || sawOther || scale >= maxAttemptEscalations {
+			break
+		}
 	}
 
 	// 2. All main providers returned 430 (or died) — try backup providers.
@@ -2455,7 +2567,7 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 				lastErr = fmt.Errorf("%s: %w", g.name, ErrQuotaExceeded)
 				continue
 			}
-			resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430)
+			resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, bodyWriter, onMeta, priority || post430, 0)
 			if cancelled {
 				err := ctx.Err()
 				if err == nil {
@@ -2465,6 +2577,9 @@ func (c *Client) doSendWithRetry(ctx context.Context, payload []byte, bodyWriter
 				return
 			}
 			if !ok {
+				if resp.Err != nil {
+					lastErr = resp.Err // expired attempts keep their reason (see the mains loop)
+				}
 				continue
 			}
 			if resp.Err != nil {

--- a/stat.go
+++ b/stat.go
@@ -132,7 +132,7 @@ func (c *Client) statOne(ctx context.Context, messageID string, target *provider
 // resilient single-group send (with fresh-connection retry on connection death)
 // that the failover path uses per provider. No cross-provider failover.
 func (c *Client) statViaGroup(ctx context.Context, g *providerGroup, payload []byte, priority bool) Response {
-	resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, nil, nil, priority)
+	resp, ok, cancelled := c.tryGroupResilient(ctx, g, payload, nil, nil, priority, 0)
 	switch {
 	case cancelled:
 		err := ctx.Err()


### PR DESCRIPTION
Closes #79.

## What happened (short version — full story in the issue)

Newshosting answers `430` for aged obfuscated message-ids in **~7.5s** (healthy articles: ~40ms). The adaptive attempt window (`4×TTFB`, floor 2s) abandons every such lookup before its answer arrives, and the abandon path returned a zero `Response` — so `lastErr` stayed nil and the terminal error was the bare `all providers exhausted`. A consumer resuming near-complete downloads (whose remaining segments are by construction the *missing* ones, i.e. exactly this class) wedges permanently: 17 hours, 330 pool recycles and a process restart changed nothing, because the latency is server-side.

## Changes — no new configuration

**1. `AttemptTimeoutError` (provider, window, phase, cause).** Returned on *both* expiry surfaces — the attempt timer, and the connection's own read deadline racing it (`expiredAwaitingResponse` normalizes them: anything short of `attemptCommitted` with a transport timeout counts) — and preserved into `lastErr`. The terminal error now reads:

```
nntp: all providers exhausted: provider-0: attempt expired after 800ms awaiting response
```

**2. Pass-level window escalation in `doSendWithRetry`.** Pass 0 runs every provider at its base window — **failover speed is untouched** (a hung provider still costs exactly one window before the next provider is tried; `TestHungProviderFailsOverFast` passes unchanged). Only when an entire pass produced *nothing but* expired-awaiting-response failures — the slow-lookup signature, never 430/quota/conn-death/saturation — is the pass re-run with the window doubled, capped at `maxAttemptTimeout`, at most `maxAttemptEscalations` (2) times. Ladder at the adaptive floor: 2s → 4s → 8s, so ~14s of bounded patience for a single-provider pool, then a typed failure.

`tryGroup` kept its signature (a thin wrapper over the new `tryGroupTimeout`); `tryGroupResilient` takes the pass's `timeoutScale`.

## Validation

- New tests: `TestSlowStatusLineEscalates` (a 430 slower than the base window must be **delivered** — before this change it could never complete at any retry count), `TestExpiredAttemptsKeepTheirReason`, `TestEscalationBounded`. Full suite + `-race` green.
- Live against Newshosting with pure adaptive defaults:

```
BODY <CpWl...@PRiVATE>   13.788s   nntp: 430 no such article   ← was: bare exhausted forever
BODY <doesnotexist@…>    37ms      nntp: 430 no such article   ← fast path untouched
```

One observation from harness work you may find interesting: when an attempt is abandoned mid-pipeline, a late-arriving status line races the drop bookkeeping — mostly it drains cleanly, occasionally the connection dies to desync protection. Escalating on fresh windows sidesteps it, but the drain path might deserve its own look someday.
